### PR TITLE
Refactor android project domain module

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+

--- a/domain/src/main/kotlin/com/bitchat/domain/model/Fragment.kt
+++ b/domain/src/main/kotlin/com/bitchat/domain/model/Fragment.kt
@@ -1,0 +1,10 @@
+package com.bitchat.domain.model
+
+data class FragmentPayload(
+    val fragmentId: ByteArray,
+    val index: Int,
+    val total: Int,
+    val originalType: UByte,
+    val data: ByteArray
+)
+

--- a/domain/src/main/kotlin/com/bitchat/domain/model/Identity.kt
+++ b/domain/src/main/kotlin/com/bitchat/domain/model/Identity.kt
@@ -1,0 +1,8 @@
+package com.bitchat.domain.model
+
+data class IdentityAnnouncement(
+    val nickname: String,
+    val noisePublicKey: ByteArray,
+    val signingPublicKey: ByteArray
+)
+

--- a/domain/src/main/kotlin/com/bitchat/domain/model/Message.kt
+++ b/domain/src/main/kotlin/com/bitchat/domain/model/Message.kt
@@ -1,0 +1,30 @@
+package com.bitchat.domain.model
+
+import java.util.Date
+
+sealed class DeliveryStatus {
+    data object Sending : DeliveryStatus()
+    data object Sent : DeliveryStatus()
+    data class Delivered(val to: String, val at: Date) : DeliveryStatus()
+    data class Read(val by: String, val at: Date) : DeliveryStatus()
+    data class Failed(val reason: String) : DeliveryStatus()
+    data class PartiallyDelivered(val reached: Int, val total: Int) : DeliveryStatus()
+}
+
+data class Message(
+    val id: String,
+    val sender: String,
+    val content: String,
+    val timestamp: Date,
+    val isRelay: Boolean = false,
+    val originalSender: String? = null,
+    val isPrivate: Boolean = false,
+    val recipientNickname: String? = null,
+    val senderPeerId: String? = null,
+    val mentions: List<String>? = null,
+    val channel: String? = null,
+    val encryptedContent: ByteArray? = null,
+    val isEncrypted: Boolean = false,
+    val deliveryStatus: DeliveryStatus? = null
+)
+

--- a/domain/src/main/kotlin/com/bitchat/domain/model/Noise.kt
+++ b/domain/src/main/kotlin/com/bitchat/domain/model/Noise.kt
@@ -1,0 +1,23 @@
+package com.bitchat.domain.model
+
+enum class NoisePayloadType(val value: UByte) {
+    PRIVATE_MESSAGE(0x01u),
+    READ_RECEIPT(0x02u),
+    DELIVERED(0x03u)
+}
+
+data class NoisePayload(
+    val type: NoisePayloadType,
+    val data: ByteArray
+)
+
+data class PrivateMessagePacket(
+    val messageId: String,
+    val content: String
+)
+
+data class ReadReceipt(
+    val originalMessageId: String,
+    val readerPeerId: String? = null
+)
+

--- a/domain/src/main/kotlin/com/bitchat/domain/repository/Repositories.kt
+++ b/domain/src/main/kotlin/com/bitchat/domain/repository/Repositories.kt
@@ -1,0 +1,46 @@
+package com.bitchat.domain.repository
+
+import com.bitchat.domain.model.*
+import kotlinx.coroutines.flow.Flow
+
+interface MessageRepository {
+    suspend fun sendMessage(message: Message): Result<Unit>
+    fun observeChannelMessages(channel: String): Flow<List<Message>>
+    suspend fun getMessageById(id: String): Message?
+    suspend fun markAsRead(messageId: String, readerPeerId: String? = null): Result<Unit>
+}
+
+interface IdentityRepository {
+    suspend fun getCurrentIdentityAnnouncement(): IdentityAnnouncement?
+    suspend fun saveIdentityAnnouncement(announcement: IdentityAnnouncement)
+    fun fingerprint(publicKey: ByteArray): String
+}
+
+interface FavoritesRepository {
+    suspend fun getFavoriteStatus(noisePublicKey: ByteArray): FavoriteRelationship?
+    suspend fun updateFavoriteStatus(noisePublicKey: ByteArray, nickname: String, isFavorite: Boolean)
+    suspend fun updatePeerFavoritedUs(noisePublicKey: ByteArray, theyFavoritedUs: Boolean)
+    suspend fun updateNostrPublicKey(noisePublicKey: ByteArray, nostrPubkey: String)
+    suspend fun getMutualFavorites(): List<FavoriteRelationship>
+    suspend fun getOurFavorites(): List<FavoriteRelationship>
+}
+
+data class FavoriteRelationship(
+    val peerNoisePublicKey: ByteArray,
+    val peerNostrPublicKey: String?,
+    val peerNickname: String,
+    val isFavorite: Boolean,
+    val theyFavoritedUs: Boolean
+)
+
+interface MessageRetentionRepository {
+    fun getFavoriteChannels(): Set<String>
+    fun toggleFavoriteChannel(channel: String): Boolean
+    fun isChannelBookmarked(channel: String): Boolean
+    suspend fun saveMessage(message: Message, channel: String)
+    suspend fun loadMessagesForChannel(channel: String): List<Message>
+    suspend fun deleteMessagesForChannel(channel: String)
+    suspend fun deleteAllStoredMessages()
+    fun getBookmarkedChannelsCount(): Int
+}
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,3 +15,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "bitchat-android"
 include(":app")
+include(":domain")


### PR DESCRIPTION
# Description

This PR initiates the Clean Architecture refactoring by introducing the `domain` module.

The primary objective is to establish a fully independent core business logic layer, free from Android framework dependencies. This separation enhances testability, scalability, and maintainability by strictly adhering to SOLID principles, especially the Dependency Inversion Principle.

The `domain` module now contains:
-   Pure Kotlin business entities (e.g., `Message`, `IdentityAnnouncement`).
-   Abstract repository interfaces (e.g., `MessageRepository`, `IdentityRepository`) that define data access contracts using these domain models and Kotlin Flow.

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests

---
<a href="https://cursor.com/background-agent?bcId=bc-a90130a1-0ebb-4083-ac11-7e73d04f14c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a90130a1-0ebb-4083-ac11-7e73d04f14c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

