### PR TITLE
mesh: complete pure BLE transport parity and audit fixes

### DIFF
--- a/core/data/src/androidHostTest/kotlin/com/app/data/voice/VoiceRepositoryImplTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/app/data/voice/VoiceRepositoryImplTest.kt
@@ -27,6 +27,10 @@ class VoiceRepositoryImplTest {
         private val frames = MutableSharedFlow<PublicVoiceFrame>(extraBufferCapacity = 64)
         override val publicVoiceFrames: Flow<PublicVoiceFrame> = frames
 
+        fun emit(payload: ByteArray, fromPeerId: String = peerId) {
+            assertTrue(frames.tryEmit(PublicVoiceFrame(fromPeerId, payload, timestampMs = 0)))
+        }
+
         override fun broadcastVoiceFrame(payload: ByteArray) {
             sent += payload
             frames.tryEmit(PublicVoiceFrame(peerId, payload, timestampMs = 0))
@@ -65,6 +69,28 @@ class VoiceRepositoryImplTest {
         override fun sendBoardPayload(payload: ByteArray) = Unit
         override var prekeyEventListener: com.app.transport.prekey.PrekeyEventListener? = null
         override fun sendPrekeyBundle(payload: ByteArray) = Unit
+    }
+
+    private fun packet(
+        burst: Int,
+        kind: VoiceBurstPacket.Kind,
+        sequence: Int = 0,
+    ): ByteArray = VoiceBurstPacket(
+        burstId = ByteArray(VoiceBurstPacket.BURST_ID_SIZE) { burst.toByte() },
+        seq = sequence.toUShort(),
+        kind = kind,
+    ).encode()
+
+    private fun LoopbackMesh.start(burst: Int) {
+        emit(packet(burst, VoiceBurstPacket.Kind.Start(VoiceBurstPacket.Codec.AAC_LC_16K_MONO)))
+    }
+
+    private fun LoopbackMesh.frames(burst: Int, vararg frames: ByteArray) {
+        emit(packet(burst, VoiceBurstPacket.Kind.Frames(frames.toList()), sequence = 1))
+    }
+
+    private fun LoopbackMesh.end(burst: Int, durationMs: Int = 100) {
+        emit(packet(burst, VoiceBurstPacket.Kind.End(totalDataPackets = 1u, durationMs = durationMs.toUInt()), sequence = 2))
     }
 
     @Test
@@ -106,5 +132,109 @@ class VoiceRepositoryImplTest {
         val mesh = LoopbackMesh(peerId = "peer1")
         VoiceRepositoryImpl(mesh).broadcast(listOf(ByteArray(0)), durationMs = 10)
         assertTrue(mesh.sent.isEmpty())
+    }
+
+    @Test
+    fun thirtyThirdIncompleteAssemblyEvictsOldestInsertion() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mesh = LoopbackMesh(peerId = "peer1")
+        val repo = VoiceRepositoryImpl(mesh)
+        val received = mutableListOf<com.app.domain.model.VoiceBurst>()
+        val job = launch(dispatcher) { repo.incomingBursts.collect { received += it } }
+
+        repeat(VoiceRepositoryImpl.MAX_PENDING_ASSEMBLIES + 1) { mesh.start(it) }
+        mesh.frames(0, "evicted".encodeToByteArray())
+        mesh.end(0)
+        mesh.frames(1, "retained".encodeToByteArray())
+        mesh.end(1)
+
+        assertEquals(listOf("retained"), received.flatMap { it.frames }.map { it.decodeToString() })
+        job.cancel()
+    }
+
+    @Test
+    fun burstOverByteBudgetIsRemovedAndEndDoesNotEmit() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mesh = LoopbackMesh(peerId = "peer1")
+        val repo = VoiceRepositoryImpl(mesh)
+        val received = mutableListOf<com.app.domain.model.VoiceBurst>()
+        val job = launch(dispatcher) { repo.incomingBursts.collect { received += it } }
+
+        mesh.start(1)
+        mesh.frames(1, *Array(VoiceBurstPacket.MAX_FRAMES_PER_PACKET) { ByteArray(UShort.MAX_VALUE.toInt()) })
+        mesh.frames(1, ByteArray(9))
+        mesh.end(1)
+
+        assertTrue(received.isEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun assemblyOlderThanTimeoutIsRemovedUsingInjectedClock() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mesh = LoopbackMesh(peerId = "peer1")
+        var now = 1_000L
+        val repo = VoiceRepositoryImpl(mesh, nowMs = { now })
+        val received = mutableListOf<com.app.domain.model.VoiceBurst>()
+        val job = launch(dispatcher) { repo.incomingBursts.collect { received += it } }
+
+        mesh.start(1)
+        now += VoiceRepositoryImpl.PENDING_TIMEOUT_MS + 1
+        mesh.frames(1, "late".encodeToByteArray())
+        mesh.end(1)
+
+        assertTrue(received.isEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun duplicateStartAtCapacityDoesNotEvictUnrelatedBurst() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mesh = LoopbackMesh(peerId = "peer1")
+        val repo = VoiceRepositoryImpl(mesh)
+        val received = mutableListOf<com.app.domain.model.VoiceBurst>()
+        val job = launch(dispatcher) { repo.incomingBursts.collect { received += it } }
+
+        repeat(VoiceRepositoryImpl.MAX_PENDING_ASSEMBLIES) { mesh.start(it) }
+        mesh.start(VoiceRepositoryImpl.MAX_PENDING_ASSEMBLIES - 1)
+        mesh.frames(0, "oldest-unrelated".encodeToByteArray())
+        mesh.end(0)
+
+        assertEquals(listOf("oldest-unrelated"), received.single().frames.map { it.decodeToString() })
+        job.cancel()
+    }
+
+    @Test
+    fun newBurstReassemblesAfterEvictionAndTimeout() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mesh = LoopbackMesh(peerId = "peer1")
+        var now = 1_000L
+        val repo = VoiceRepositoryImpl(mesh, nowMs = { now })
+        val received = mutableListOf<com.app.domain.model.VoiceBurst>()
+        val job = launch(dispatcher) { repo.incomingBursts.collect { received += it } }
+
+        repeat(VoiceRepositoryImpl.MAX_PENDING_ASSEMBLIES + 1) { mesh.start(it) }
+        now += VoiceRepositoryImpl.PENDING_TIMEOUT_MS + 1
+        mesh.start(100)
+        mesh.frames(100, "fresh".encodeToByteArray())
+        mesh.end(100)
+
+        assertEquals(listOf("fresh"), received.single().frames.map { it.decodeToString() })
+        job.cancel()
+    }
+
+    @Test
+    fun framesWithoutStartDoNotCreateAssembly() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mesh = LoopbackMesh(peerId = "peer1")
+        val repo = VoiceRepositoryImpl(mesh)
+        val received = mutableListOf<com.app.domain.model.VoiceBurst>()
+        val job = launch(dispatcher) { repo.incomingBursts.collect { received += it } }
+
+        mesh.frames(1, "orphan".encodeToByteArray())
+        mesh.end(1)
+
+        assertTrue(received.isEmpty())
+        job.cancel()
     }
 }

--- a/core/data/src/commonMain/kotlin/com/app/data/nostr/NostrDirectMessageIngest.kt
+++ b/core/data/src/commonMain/kotlin/com/app/data/nostr/NostrDirectMessageIngest.kt
@@ -238,7 +238,9 @@ class NostrDirectMessageIngest(
             NoisePayloadType.VOUCH,
             // Group state is creator-authenticated over a 1:1 mesh Noise session; not carried over Nostr.
             NoisePayloadType.GROUP_INVITE,
-            NoisePayloadType.GROUP_KEY_UPDATE -> Unit // not carried over Nostr DMs
+            NoisePayloadType.GROUP_KEY_UPDATE,
+            // Live private voice (0x08) is mesh-Noise only; never carried over Nostr DMs.
+            NoisePayloadType.VOICE_FRAME -> Unit // not carried over Nostr DMs
         }
     }
 

--- a/core/data/src/commonMain/kotlin/com/app/data/routing/RoutingMessageTransport.kt
+++ b/core/data/src/commonMain/kotlin/com/app/data/routing/RoutingMessageTransport.kt
@@ -32,6 +32,10 @@ internal class RoutingMessageTransport(
         mesh.sendMessage(content, mentions, channel)
     }
 
+    override suspend fun sendPublic(content: String, mentions: List<String>, channel: String?, messageId: String) {
+        mesh.sendMessage(content, mentions, channel, messageId)
+    }
+
     override suspend fun sendPrivate(content: String, to: PeerId, recipientNickname: String?, messageId: String) {
         router.sendPrivate(content, to.raw, recipientNickname ?: "", messageId)
     }

--- a/core/data/src/commonMain/kotlin/com/app/data/voice/VoiceRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/app/data/voice/VoiceRepositoryImpl.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.app.data.voice
 
 import com.app.domain.model.VoiceBurst
@@ -10,35 +12,91 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.random.Random
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /**
  * Packages/reassembles live voice (0x29) over the mesh. Outbound: a Start marker, the frames chunked
  * to at most [VoiceBurstPacket.MAX_FRAMES_PER_PACKET] per wire packet with an increasing sequence,
  * then an End marker. Inbound: groups incoming packets by (peer, burst id) and emits a [VoiceBurst]
  * once its End arrives. Stateless across bursts — nothing is persisted.
+ *
+ * Inbound pending map is hard-bounded (assembly count, frame bytes, age) so a flood of
+ * incomplete Starts cannot grow without limit.
  */
 @SingleIn(AppScope::class)
 @Inject
 internal class VoiceRepositoryImpl(
     private val meshService: MeshService,
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) : VoiceRepository {
 
+    private data class PendingBurst(
+        val frames: MutableList<ByteArray> = mutableListOf(),
+        var bytes: Int = 0,
+        val startedAtMs: Long,
+    )
+
+    companion object {
+        /** Max concurrent incomplete bursts. */
+        const val MAX_PENDING_ASSEMBLIES: Int = 32
+        /** Max payload frames bytes per incomplete burst. */
+        const val MAX_PENDING_BYTES_PER_BURST: Int = 512 * 1024
+        /** Drop incomplete assemblies older than this. */
+        const val PENDING_TIMEOUT_MS: Long = 30_000L
+    }
+
     override val incomingBursts: Flow<VoiceBurst> = flow {
-        val pending = mutableMapOf<String, MutableList<ByteArray>>()
+        val pending = linkedMapOf<String, PendingBurst>()
         meshService.publicVoiceFrames.collect { frame ->
             val packet = VoiceBurstPacket.decode(frame.payload) ?: return@collect
-            val key = frame.peerId + ":" + packet.burstId.joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+            val key = frame.peerId + ":" + packet.burstId.joinToString("") {
+                (it.toInt() and 0xFF).toString(16).padStart(2, '0')
+            }
+            val now = nowMs()
+            prunePending(pending, now)
+
             when (val kind = packet.kind) {
-                is VoiceBurstPacket.Kind.Start -> pending[key] = mutableListOf()
-                is VoiceBurstPacket.Kind.Frames -> pending.getOrPut(key) { mutableListOf() }.addAll(kind.frames)
+                is VoiceBurstPacket.Kind.Start -> {
+                    if (key !in pending) ensureCapacity(pending)
+                    pending[key] = PendingBurst(startedAtMs = now)
+                }
+                is VoiceBurstPacket.Kind.Frames -> {
+                    val entry = pending[key] ?: return@collect
+                    for (f in kind.frames) {
+                        if (entry.bytes + f.size > MAX_PENDING_BYTES_PER_BURST) {
+                            pending.remove(key)
+                            return@collect
+                        }
+                        entry.frames.add(f)
+                        entry.bytes += f.size
+                    }
+                }
                 is VoiceBurstPacket.Kind.End -> {
-                    val frames = pending.remove(key)
-                    if (!frames.isNullOrEmpty()) {
-                        emit(VoiceBurst(frame.peerId, frames, kind.durationMs.toInt()))
+                    val entry = pending.remove(key)
+                    if (entry != null && entry.frames.isNotEmpty()) {
+                        emit(VoiceBurst(frame.peerId, entry.frames, kind.durationMs.toInt()))
                     }
                 }
                 VoiceBurstPacket.Kind.Canceled -> pending.remove(key)
             }
+        }
+    }
+
+    private fun prunePending(pending: MutableMap<String, PendingBurst>, now: Long) {
+        val cutoff = now - PENDING_TIMEOUT_MS
+        val it = pending.entries.iterator()
+        while (it.hasNext()) {
+            if (it.next().value.startedAtMs < cutoff) it.remove()
+        }
+    }
+
+    private fun ensureCapacity(pending: MutableMap<String, PendingBurst>) {
+        while (pending.size >= MAX_PENDING_ASSEMBLIES) {
+            val oldest = pending.entries.iterator()
+            if (!oldest.hasNext()) break
+            oldest.next()
+            oldest.remove()
         }
     }
 

--- a/core/domain/src/commonMain/kotlin/com/app/domain/repository/MessageTransport.kt
+++ b/core/domain/src/commonMain/kotlin/com/app/domain/repository/MessageTransport.kt
@@ -14,6 +14,10 @@ interface MessageTransport {
     /** Public/channel message (channel == null -> shared mesh chat). */
     suspend fun sendPublic(content: String, mentions: List<String>, channel: String?)
 
+    /** Public/channel message whose relayed self-copy must retain [messageId]. */
+    suspend fun sendPublic(content: String, mentions: List<String>, channel: String?, messageId: String) =
+        sendPublic(content, mentions, channel)
+
     /** Private message. The route (mesh/Nostr) is chosen by the implementation. */
     suspend fun sendPrivate(content: String, to: PeerId, recipientNickname: String?, messageId: String)
 

--- a/core/domain/src/commonMain/kotlin/com/app/domain/usecase/SendMessageUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/app/domain/usecase/SendMessageUseCase.kt
@@ -41,12 +41,12 @@ class SendMessageUseCase(
         when (target) {
             is ConversationId.PublicMesh -> {
                 messages.append(target, echo(id, target, sender, content, now, mentions))
-                transport.sendPublic(content, mentions, channel = null)
+                transport.sendPublic(content, mentions, channel = null, messageId = id)
             }
 
             is ConversationId.Channel -> {
                 messages.append(target, echo(id, target, sender, content, now, mentions))
-                transport.sendPublic(content, mentions, channel = target.tag)
+                transport.sendPublic(content, mentions, channel = target.tag, messageId = id)
             }
 
             is ConversationId.Private -> {

--- a/core/domain/src/commonTest/kotlin/com/app/domain/Fakes.kt
+++ b/core/domain/src/commonTest/kotlin/com/app/domain/Fakes.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.flowOf
 
 /** Records outgoing transport calls. */
 class FakeMessageTransport : MessageTransport {
-    data class Public(val content: String, val mentions: List<String>, val channel: String?)
+    data class Public(val content: String, val mentions: List<String>, val channel: String?, val messageId: String)
     data class Private(val content: String, val to: PeerId, val recipientNickname: String?, val messageId: String)
     data class Geo(val content: String, val channel: GeohashChannel, val nickname: String?)
     data class Receipt(val messageId: String, val to: PeerId)
@@ -45,7 +45,11 @@ class FakeMessageTransport : MessageTransport {
     var cancelResult = true
 
     override suspend fun sendPublic(content: String, mentions: List<String>, channel: String?) {
-        publics += Public(content, mentions, channel)
+        publics += Public(content, mentions, channel, "")
+    }
+
+    override suspend fun sendPublic(content: String, mentions: List<String>, channel: String?, messageId: String) {
+        publics += Public(content, mentions, channel, messageId)
     }
 
     override suspend fun sendPrivate(content: String, to: PeerId, recipientNickname: String?, messageId: String) {

--- a/core/domain/src/commonTest/kotlin/com/app/domain/usecase/SendMessageUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/app/domain/usecase/SendMessageUseCaseTest.kt
@@ -46,6 +46,7 @@ class SendMessageUseCaseTest {
         assertEquals(listOf("bob"), echo.mentions)
         assertEquals(1, transport.publics.size)
         assertEquals(null, transport.publics.single().channel)
+        assertEquals(echo.id, transport.publics.single().messageId)
     }
 
     @Test fun `channel message routes with tag`() = runTest {
@@ -55,6 +56,7 @@ class SendMessageUseCaseTest {
 
         assertEquals(target, repo.appended.single().first)
         assertEquals("#dev", transport.publics.single().channel)
+        assertEquals(repo.appended.single().second.id, transport.publics.single().messageId)
     }
 
     @Test fun `private message echoes Sending and sends with id`() = runTest {

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/BleBearerIngressDropTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/BleBearerIngressDropTest.kt
@@ -55,10 +55,12 @@ class BleBearerIngressDropTest {
 
     private fun packet(marker: ULong): BitchatPacket = BitchatPacket(
         type = MessageType.MESSAGE.value,
-        senderID = ByteArray(8),
+        // Non-local sender so BleIngressPacketGuard does not treat this as self-loopback.
+        senderID = byteArrayOf(0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22),
         recipientID = null,
-        timestamp = marker,
-        payload = ByteArray(0),
+        // Wall-clock timestamps (ingress guard rejects >120s skew from now).
+        timestamp = (System.currentTimeMillis() + marker.toLong()).toULong(),
+        payload = byteArrayOf(marker.toByte()),
         ttl = 1u,
     )
 
@@ -89,15 +91,16 @@ class BleBearerIngressDropTest {
         }
 
         assertEquals("buffer retains exactly `capacity` frames", capacity, received.size)
+        // Markers live in payload[0] (timestamps are wall-clock for the ingress skew gate).
         assertEquals(
             "oldest surviving frame is marker $overflow (0..${overflow - 1} dropped)",
-            overflow.toULong(),
-            received.first().packet.timestamp,
+            overflow.toByte(),
+            received.first().packet.payload.first(),
         )
         assertEquals(
             "newest frame is always retained",
-            (total - 1).toULong(),
-            received.last().packet.timestamp,
+            (total - 1).toByte(),
+            received.last().packet.payload.first(),
         )
     }
 

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/BleIngressLinkRegistryConcurrencyTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/BleIngressLinkRegistryConcurrencyTest.kt
@@ -1,0 +1,59 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BleIngressLinkRegistryConcurrencyTest {
+
+    @Test
+    fun concurrentWritersNeverExceedHardCap() {
+        val registry = BleIngressLinkRegistry()
+        val workers = 8
+        val recordsPerWorker = 1_000
+        val ready = CountDownLatch(workers)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(workers)
+        val pool = Executors.newFixedThreadPool(workers)
+
+        repeat(workers) { worker ->
+            pool.execute {
+                ready.countDown()
+                start.await()
+                repeat(recordsPerWorker) { offset ->
+                    val index = worker * recordsPerWorker + offset
+                    registry.recordIfNew(
+                        packet = BitchatPacket(
+                            version = 1u,
+                            type = MessageType.MESSAGE.value,
+                            senderID = peerIdToRoutingBytes("1111111111111111"),
+                            recipientID = null,
+                            timestamp = (1_700_000_000_000L + index).toULong(),
+                            payload = byteArrayOf((index % 251).toByte()),
+                            signature = null,
+                            ttl = 7u,
+                        ),
+                        link = BleIngressLinkId.Peripheral("link-$worker"),
+                        peerID = "peer-$worker",
+                        nowMs = index.toLong(),
+                        lifetimeMs = Long.MAX_VALUE,
+                    )
+                }
+                done.countDown()
+            }
+        }
+
+        assertTrue(ready.await(5, TimeUnit.SECONDS))
+        start.countDown()
+        assertTrue(done.await(20, TimeUnit.SECONDS))
+        pool.shutdownNow()
+
+        assertEquals(4096, registry.debugRecordCount())
+    }
+}

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/MeshCoordinatorLifecycleTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/MeshCoordinatorLifecycleTest.kt
@@ -18,6 +18,7 @@ import com.app.transport.model.RoutedPacket
 import com.app.transport.notification.ServiceNotifier
 import com.app.transport.protocol.BitchatPacket
 import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -170,11 +171,16 @@ class BluetoothMeshServiceLifecycleTest {
             scheduler.runCurrent()
         }
 
-        /** LEAVE skips signature verification, so it traverses the engine with mocked crypto. */
-        fun leavePacket(timestamp: ULong) = BitchatPacket(
+        /**
+         * LEAVE skips signature verification, so it traverses the engine with mocked crypto.
+         * Timestamp defaults to wall-clock "now" so the 120s ingress skew gate accepts the
+         * probe (fixed epoch values like 1000u fail SecurityManager clock skew).
+         */
+        fun leavePacket(timestamp: ULong = System.currentTimeMillis().toULong()) = BitchatPacket(
             type = MessageType.LEAVE.value,
             ttl = 3u,
-            senderID = ByteArray(8) { 0x22 },
+            // Logical author must match REMOTE_PEER so BleBearer ingress + engine probes agree.
+            senderID = peerIdToRoutingBytes(REMOTE_PEER),
             payload = ByteArray(0),
             timestamp = timestamp,
         )
@@ -184,9 +190,17 @@ class BluetoothMeshServiceLifecycleTest {
          * delivered it to the engine (logIncomingPacket fires past security validation on
          * the PacketProcessor's real-IO actor, hence the verify timeout). Exactly-once also
          * guards against a zombie generation double-processing.
+         *
+         * Each call uses a distinct payload so message-id dedup does not collapse probes.
          */
-        fun assertEngineReceives(timestamp: ULong) {
-            fakeBearer.incomingFlow.tryEmit(RoutedPacket(leavePacket(timestamp), REMOTE_PEER, "WIFI-1"))
+        private var probeSeq = 0
+        fun assertEngineReceives(timestamp: ULong? = null) {
+            probeSeq += 1
+            val packet = leavePacket(timestamp ?: System.currentTimeMillis().toULong()).let {
+                // Distinct payload per probe so SecurityManager messageID differs.
+                it.copy(payload = byteArrayOf(probeSeq.toByte()))
+            }
+            fakeBearer.incomingFlow.tryEmit(RoutedPacket(packet, REMOTE_PEER, "WIFI-1"))
             scheduler.runCurrent()
             verify(telemetry, timeout(5_000).times(1))
                 .logIncomingPacket(eq(REMOTE_PEER), anyOrNull(), eq("LEAVE"), anyOrNull())
@@ -217,7 +231,7 @@ class BluetoothMeshServiceLifecycleTest {
         verify(h.managers[1], timeout(1_000)).startServices()
 
         // No zombie: the new generation's collector receives packets, exactly once.
-        h.assertEngineReceives(timestamp = 1_000u)
+        h.assertEngineReceives()
     }
 
     // ------------------------------------------------------------------
@@ -238,7 +252,7 @@ class BluetoothMeshServiceLifecycleTest {
         h.advancePastGrace()
 
         assertTrue("new generation must stay active", h.bms.isMeshActive)
-        h.assertEngineReceives(timestamp = 2_000u)
+        h.assertEngineReceives()
     }
 
     /**
@@ -262,7 +276,7 @@ class BluetoothMeshServiceLifecycleTest {
         h.bms.simulateStaleTeardown(gen1Scope)
 
         assertTrue("stale teardown must not deactivate the new generation", h.bms.isMeshActive)
-        h.assertEngineReceives(timestamp = 5_000u)
+        h.assertEngineReceives()
 
         // And the service must still stop normally afterwards (not marked terminated).
         h.bms.stopServices()
@@ -296,12 +310,12 @@ class BluetoothMeshServiceLifecycleTest {
         h.advancePastGrace()
 
         assertFalse(h.bms.isMeshActive)
-        verify(h.managers[0], times(1)).stopServices()
+        verify(h.managers[0], times(1)).shutdown()
 
         // A terminated service must revive on the next start.
         h.startAndSettle()
         assertTrue(h.bms.isMeshActive)
-        h.assertEngineReceives(timestamp = 3_000u)
+        h.assertEngineReceives()
     }
 
     // ------------------------------------------------------------------
@@ -323,7 +337,7 @@ class BluetoothMeshServiceLifecycleTest {
         assertTrue("mesh must be active after panic reset", h.bms.isMeshActive)
         assertNotEquals(oldPeerId, h.bms.myPeerID)
         assertEquals(FINGERPRINT_B.take(16), h.bms.myPeerID)
-        h.assertEngineReceives(timestamp = 4_000u)
+        h.assertEngineReceives()
     }
 
     // ------------------------------------------------------------------
@@ -346,7 +360,7 @@ class BluetoothMeshServiceLifecycleTest {
         // reset() must have detached the old stack's delegate (the GATT stack reaches its
         // delegate exclusively through this field, so null = isolated).
         assertNull("old connection manager delegate must be detached", h.delegates[oldCm])
-        verify(oldCm).stopServices()
+        verify(oldCm).shutdown()
 
         val newCm = h.managers.last()
         assertNotEquals(oldCm, newCm)
@@ -359,7 +373,7 @@ class BluetoothMeshServiceLifecycleTest {
         // incoming flow is single-consumer (owned by the coordinator's merge), so engine
         // traversal is observed at logIncomingPacket — the suite's canonical probe — rather than
         // a second competing collector on the flow.
-        h.delegates[oldCm]?.onPacketReceived(h.leavePacket(9_000u), "stalePeer", null)
+        h.delegates[oldCm]?.onPacketReceived(h.leavePacket(), "stalePeer", null)
         h.delegates[oldCm]?.onDeviceDisconnected("AA:BB:CC:DD:EE:FF")
         h.scheduler.runCurrent()
 
@@ -374,7 +388,7 @@ class BluetoothMeshServiceLifecycleTest {
         // Sanity: the NEW stack's delegate is live and its packets traverse the current
         // generation's collector → PacketProcessor pipeline.
         assertNotNull(h.delegates[newCm])
-        h.delegates[newCm]?.onPacketReceived(h.leavePacket(9_001u), REMOTE_PEER, null)
+        h.delegates[newCm]?.onPacketReceived(h.leavePacket(), REMOTE_PEER, null)
         h.scheduler.runCurrent()
         verify(h.telemetry, timeout(5_000).times(1))
             .logIncomingPacket(eq(REMOTE_PEER), anyOrNull(), eq("LEAVE"), anyOrNull())

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/PacketProcessorFifoOrderTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/PacketProcessorFifoOrderTest.kt
@@ -26,8 +26,11 @@ class PacketProcessorFifoOrderTest {
     private val myPeerID = "1111111111111111"
 
     private class RecordingDelegate(val order: MutableList<Int>) : PacketProcessorDelegate {
-        override fun validatePacketSecurity(packet: BitchatPacket, peerID: String) =
-            PacketValidationResult.ACCEPT
+        override fun validatePacketSecurity(
+            packet: BitchatPacket,
+            peerID: String,
+            previousHopPeerID: String?,
+        ) = PacketValidationResult.ACCEPT
         override fun handleDuplicateAnnounceLiveness(routed: RoutedPacket) {}
         override fun updatePeerLastSeen(peerID: String) {}
         override fun getPeerNickname(peerID: String): String? = null
@@ -41,7 +44,7 @@ class PacketProcessorFifoOrderTest {
             order.add(routed.packet.timestamp.toInt())
         }
         override fun handleLeave(routed: RoutedPacket) {}
-        override fun handleFragment(packet: BitchatPacket): BitchatPacket? = null
+        override fun handleFragment(routed: RoutedPacket): BitchatPacket? = null
         override fun handleRequestSync(routed: RoutedPacket) {}
         override fun handlePing(routed: RoutedPacket, linkKey: String) {}
         override fun handlePong(routed: RoutedPacket) {}

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/PacketProcessorMessageRateLimitTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/PacketProcessorMessageRateLimitTest.kt
@@ -27,8 +27,11 @@ class PacketProcessorMessageRateLimitTest {
     private class RecordingDelegate : PacketProcessorDelegate {
         val handled = CopyOnWriteArrayList<Int>()
         val relayed = CopyOnWriteArrayList<Int>()
-        override fun validatePacketSecurity(packet: BitchatPacket, peerID: String) =
-            PacketValidationResult.ACCEPT
+        override fun validatePacketSecurity(
+            packet: BitchatPacket,
+            peerID: String,
+            previousHopPeerID: String?,
+        ) = PacketValidationResult.ACCEPT
         override fun handleDuplicateAnnounceLiveness(routed: RoutedPacket) {}
         override fun updatePeerLastSeen(peerID: String) {}
         override fun getPeerNickname(peerID: String): String? = null
@@ -42,7 +45,7 @@ class PacketProcessorMessageRateLimitTest {
             handled.add(routed.packet.timestamp.toInt())
         }
         override fun handleLeave(routed: RoutedPacket) {}
-        override fun handleFragment(packet: BitchatPacket): BitchatPacket? = null
+        override fun handleFragment(routed: RoutedPacket): BitchatPacket? = null
         override fun handleRequestSync(routed: RoutedPacket) {}
         override fun handlePing(routed: RoutedPacket, linkKey: String) {}
         override fun handlePong(routed: RoutedPacket) {}

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/PacketProcessorVoiceFrameTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/PacketProcessorVoiceFrameTest.kt
@@ -20,7 +20,11 @@ class PacketProcessorVoiceFrameTest {
         val received = CopyOnWriteArrayList<ULong>()
         val relayed = CopyOnWriteArrayList<ULong>()
 
-        override fun validatePacketSecurity(packet: BitchatPacket, peerID: String) = PacketValidationResult.ACCEPT
+        override fun validatePacketSecurity(
+            packet: BitchatPacket,
+            peerID: String,
+            previousHopPeerID: String?,
+        ) = PacketValidationResult.ACCEPT
         override fun handleDuplicateAnnounceLiveness(routed: RoutedPacket) = Unit
         override fun updatePeerLastSeen(peerID: String) = Unit
         override fun getPeerNickname(peerID: String): String? = null
@@ -32,7 +36,7 @@ class PacketProcessorVoiceFrameTest {
         override fun handleAnnounce(routed: RoutedPacket) = Unit
         override fun handleMessage(routed: RoutedPacket) = Unit
         override fun handleLeave(routed: RoutedPacket) = Unit
-        override fun handleFragment(packet: BitchatPacket): BitchatPacket? = null
+        override fun handleFragment(routed: RoutedPacket): BitchatPacket? = null
         override fun handleRequestSync(routed: RoutedPacket) = Unit
         override fun handlePing(routed: RoutedPacket, linkKey: String) = Unit
         override fun handlePong(routed: RoutedPacket) = Unit

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/RsrMultiHopSecurityManagerTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/RsrMultiHopSecurityManagerTest.kt
@@ -1,0 +1,240 @@
+package com.app.transport.mesh
+
+import android.os.Build
+import com.app.crypto.EncryptionService
+import com.app.crypto.identity.PeerFingerprintManager
+import com.app.crypto.secure.SecureKeyValueStore
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * P0.2: multi-hop RSR through SecurityManager —
+ * solicitation against hop B, logical author C as peerID (signature path).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], manifest = Config.NONE)
+class RsrMultiHopSecurityManagerTest {
+
+    private val myPeer = "0a0b0c0d0e0f1011"
+    private val hopPeer = "bbbbbbbbbbbbbbbb"
+    private val authorPeer = "aaaaaaaaaaaaaaaa"
+
+    private object NoopStore : SecureKeyValueStore {
+        override fun getString(key: String): String? = null
+        override fun putString(key: String, value: String) {}
+        override fun getStringSet(key: String): Set<String>? = null
+        override fun putStringSet(key: String, values: Set<String>) {}
+        override fun contains(key: String): Boolean = false
+        override fun remove(vararg keys: String) {}
+        override suspend fun clear() {}
+    }
+
+    private class FakeEncryption : EncryptionService(NoopStore, PeerFingerprintManager()) {
+        override fun initialize() {}
+    }
+
+    private var securityManager: SecurityManager? = null
+
+    @After
+    fun tearDown() {
+        securityManager?.shutdown()
+        securityManager = null
+    }
+
+    /** LEAVE: no mandatory outer signature — isolates RSR solicitation from Ed25519. */
+    private fun oldRsrLeave() = BitchatPacket(
+        version = 1u,
+        type = MessageType.LEAVE.value,
+        senderID = peerIdToRoutingBytes(authorPeer),
+        recipientID = null,
+        timestamp = 1_000_000uL,
+        payload = byteArrayOf(),
+        signature = null,
+        ttl = 0u,
+        isRSR = true,
+    )
+
+    @Test
+    fun solicitedHop_authorAsPeerID_acceptsLeaveRsr() {
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        assertEquals(
+            PacketValidationResult.ACCEPT,
+            sm.validatePacket(oldRsrLeave(), peerID = authorPeer, previousHopPeerID = hopPeer),
+        )
+    }
+
+    @Test
+    fun missingHop_solicitationFails_evenWithAuthorPeerID() {
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        assertEquals(
+            PacketValidationResult.DROP,
+            sm.validatePacket(oldRsrLeave(), peerID = authorPeer, previousHopPeerID = null),
+        )
+    }
+
+    @Test
+    fun wrongHop_dropped() {
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        assertEquals(
+            PacketValidationResult.DROP,
+            sm.validatePacket(
+                oldRsrLeave(),
+                peerID = authorPeer,
+                previousHopPeerID = "cccccccccccccccc",
+            ),
+        )
+    }
+
+    /** Self-authored LEAVE as solicited RSR (ttl=0) — iOS selfAuthoredSyncReplayIsAccepted. */
+    private fun selfAuthoredRsrLeave() = BitchatPacket(
+        version = 1u,
+        type = MessageType.LEAVE.value,
+        senderID = peerIdToRoutingBytes(myPeer),
+        recipientID = null,
+        timestamp = 1_000_000uL,
+        payload = byteArrayOf(),
+        signature = null,
+        ttl = 0u,
+        isRSR = true,
+    )
+
+    @Test
+    fun selfAuthoredSolicitedRsr_accepted() {
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        assertEquals(
+            PacketValidationResult.ACCEPT,
+            sm.validatePacket(
+                selfAuthoredRsrLeave(),
+                peerID = myPeer,
+                previousHopPeerID = hopPeer,
+            ),
+        )
+    }
+
+    @Test
+    fun selfAuthoredWithoutRsr_droppedAsLoopback() {
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        val echo = selfAuthoredRsrLeave().copy(isRSR = false, ttl = 3u)
+        assertEquals(
+            PacketValidationResult.DROP,
+            sm.validatePacket(echo, peerID = myPeer, previousHopPeerID = hopPeer),
+        )
+    }
+
+    @Test
+    fun selfAuthoredRsr_unsolicitedHop_dropped() {
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        assertEquals(
+            PacketValidationResult.DROP,
+            sm.validatePacket(
+                selfAuthoredRsrLeave(),
+                peerID = myPeer,
+                previousHopPeerID = null,
+            ),
+        )
+    }
+
+    @Test
+    fun selfAuthoredMessageRsr_unsignedIsDropped() {
+        // MESSAGE requires Ed25519 with our signing key; missing signature must DROP
+        // even when solicitation is valid (must not skip crypto for self-RSR).
+        val sm = SecurityManager(
+            encryptionService = FakeEncryption(),
+            myPeerID = myPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        val unsigned = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(myPeer),
+            recipientID = null,
+            timestamp = 1_000_000uL,
+            payload = "hi".encodeToByteArray(),
+            signature = null,
+            ttl = 0u,
+            isRSR = true,
+        )
+        assertEquals(
+            PacketValidationResult.DROP,
+            sm.validatePacket(unsigned, peerID = myPeer, previousHopPeerID = hopPeer),
+        )
+    }
+
+    @Test
+    fun selfAuthoredMessageRsr_signedWithOwnKey_accepted() {
+        // Real Ed25519 keys (do not override initialize) so getSigningPublicKey/signData work.
+        val enc = EncryptionService(NoopStore, PeerFingerprintManager())
+        val localPeer = enc.getIdentityFingerprint().take(16)
+        val sm = SecurityManager(
+            encryptionService = enc,
+            myPeerID = localPeer,
+            nowMillis = { 1_700_000_000_000L },
+            isValidSyncResponse = { it == hopPeer },
+        ).also { securityManager = it }
+
+        val unsigned = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(localPeer),
+            recipientID = null,
+            timestamp = 1_000_000uL,
+            payload = "self-rsr-history".encodeToByteArray(),
+            signature = null,
+            ttl = 0u,
+            isRSR = true,
+        )
+        val toSign = requireNotNull(unsigned.toBinaryDataForSigning())
+        val signature = requireNotNull(enc.signData(toSign))
+        val signed = unsigned.copy(signature = signature)
+
+        assertEquals(
+            PacketValidationResult.ACCEPT,
+            sm.validatePacket(signed, peerID = localPeer, previousHopPeerID = hopPeer),
+        )
+    }
+}

--- a/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/SecurityManagerTest.kt
+++ b/transport/mesh/src/androidHostTest/kotlin/com/app/transport/mesh/SecurityManagerTest.kt
@@ -71,12 +71,24 @@ class SecurityManagerTest {
         }
     }
 
+    /**
+     * Frozen "now" aligned with wall clock at test start. Packet fixtures that use the
+     * BitchatPacket(senderID: String) convenience ctor stamp System.currentTimeMillis();
+     * [nowMillis] must stay within 120s of those stamps for the ingress skew gate.
+     */
+    private var testNowMs: Long = 0L
+
     @Before
     fun setup() {
+        testNowMs = System.currentTimeMillis()
         fakeEncryptionService = FakeEncryptionService()
         mockDelegate = mock()
         
-        securityManager = SecurityManager(fakeEncryptionService, myPeerID)
+        securityManager = SecurityManager(
+            encryptionService = fakeEncryptionService,
+            myPeerID = myPeerID,
+            nowMillis = { testNowMs },
+        )
         securityManager.delegate = mockDelegate
     }
 
@@ -268,7 +280,7 @@ class SecurityManagerTest {
             type = MessageType.MESSAGE.value,
             senderID = byteArrayOf(0xAA.toByte(), 0xAA.toByte(), 0xBB.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xDD.toByte()),
             recipientID = null,
-            timestamp = 1_000_000uL,
+            timestamp = testNowMs.toULong(),
             payload = prefix + tail,
             signature = validSignature,
             ttl = 7u
@@ -291,7 +303,7 @@ class SecurityManagerTest {
             type = MessageType.MESSAGE.value,
             senderID = byteArrayOf(0xAA.toByte(), 0xAA.toByte(), 0xBB.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xDD.toByte()),
             recipientID = null,
-            timestamp = 2_000_000uL,
+            timestamp = testNowMs.toULong(),
             payload = dummyPayload,
             signature = validSignature,
             ttl = 7u
@@ -408,7 +420,8 @@ class SecurityManagerTest {
                 type = MessageType.MESSAGE.value,
                 ttl = 7u,
                 senderID = ByteArray(8) { 0xAB.toByte() },
-                timestamp = i.toULong(),
+                // Distinct timestamps within the 120s ingress skew window of [testNowMs].
+                timestamp = (testNowMs + i).toULong(),
                 payload = "m$i".encodeToByteArray(),
                 signature = validSignature,
             )

--- a/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothConnectionManager.kt
+++ b/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothConnectionManager.kt
@@ -350,6 +350,26 @@ internal class BluetoothConnectionManager(
     override fun connectToAddress(address: String): Boolean = clientManager.connectToAddress(address)
     override fun disconnectAddress(address: String) { connectionTracker.disconnectDevice(address) }
 
+    /**
+     * Central-role (GATT client) links only — used by [BleBearer] + [BleRedundantLinkPolicy]
+     * after a direct-announce bind to retire restore-era duplicate connections.
+     */
+    override fun clientLinkSnapshots(): List<BleClientLinkSnapshot> {
+        return try {
+            connectionTracker.getConnectedDevices().mapNotNull { (address, dc) ->
+                if (!dc.isClient) return@mapNotNull null
+                BleClientLinkSnapshot(
+                    address = address,
+                    peerID = addressPeerMap[address] ?: dc.peerID,
+                    isConnected = true,
+                    hasCharacteristic = dc.characteristic != null,
+                )
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
 
     // Optionally disconnect all connections (server and client)
     fun disconnectAll() {

--- a/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothConnectionManager.kt
+++ b/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothConnectionManager.kt
@@ -350,6 +350,8 @@ internal class BluetoothConnectionManager(
     override fun connectToAddress(address: String): Boolean = clientManager.connectToAddress(address)
     override fun disconnectAddress(address: String) { connectionTracker.disconnectDevice(address) }
 
+    override fun flushDirectedSpool() = packetBroadcaster.flushDirectedSpool()
+
     /**
      * Central-role (GATT client) links only — used by [BleBearer] + [BleRedundantLinkPolicy]
      * after a direct-announce bind to retire restore-era duplicate connections.

--- a/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothConnectionManager.kt
+++ b/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothConnectionManager.kt
@@ -256,27 +256,20 @@ internal class BluetoothConnectionManager(
      * Stop all Bluetooth services with proper cleanup
      */
     override fun stopServices() {
+        shutdown()
+    }
+
+    override fun shutdown() {
         Log.i(TAG, "Stopping power-optimized Bluetooth services")
-        
         isActive = false
-        
-        connectionScope.launch {
-            Log.d(TAG, "Stopping client/server and power components...")
-            // Stop component managers
-            clientManager.stop()
-            serverManager.stop()
-            
-            // Stop power manager
-            powerManager.stop()
-            
-            // Stop connection tracker
-            connectionTracker.stop()
-            
-            // Cancel the coroutine scope
-            connectionScope.cancel()
-            
-            Log.i(TAG, "All Bluetooth services stopped")
-        }
+        Log.d(TAG, "Stopping client/server and power components...")
+        clientManager.stop()
+        serverManager.stop()
+        powerManager.stop()
+        connectionTracker.stop()
+        packetBroadcaster.shutdown()
+        connectionScope.cancel()
+        Log.i(TAG, "All Bluetooth services stopped")
     }
 
     /**

--- a/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothPacketBroadcaster.kt
+++ b/transport/mesh/src/androidMain/kotlin/com/app/transport/mesh/BluetoothPacketBroadcaster.kt
@@ -85,6 +85,8 @@ internal class BluetoothPacketBroadcaster(
 
     fun cancelTransfer(transferId: String): Boolean = sendCore.cancelTransfer(transferId)
 
+    fun flushDirectedSpool() = sendCore.flushDirectedSpool()
+
     // ------------------------------------------------------------------
     // BleRadioLink — the only genuinely Android part: GATT notify/write
     // ------------------------------------------------------------------

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BearerTransport.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BearerTransport.kt
@@ -38,6 +38,9 @@ interface BearerTransport {
     fun startServices(): Boolean
     fun stopServices()
 
+    /** Terminal teardown for a transport generation; implementations must release owned scopes. */
+    fun shutdown() = stopServices()
+
     fun broadcastPacket(routed: RoutedPacket)
     fun sendToPeer(peerID: String, routed: RoutedPacket): Boolean
     fun cancelTransfer(transferId: String): Boolean

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BearerTransport.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BearerTransport.kt
@@ -66,4 +66,10 @@ interface BearerTransport {
      * Default empty so fakes/mocks do not need to implement it.
      */
     fun clientLinkSnapshots(): List<BleClientLinkSnapshot> = emptyList()
+
+    /**
+     * Drain directed packets held while no BLE links were writable ([BleDirectedRelaySpool]).
+     * Platforms that own a [BleSendCore] implement this; default is a no-op.
+     */
+    fun flushDirectedSpool() = Unit
 }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BearerTransport.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BearerTransport.kt
@@ -59,4 +59,11 @@ interface BearerTransport {
     fun connectToAddress(address: String): Boolean
     fun disconnectAddress(address: String)
     fun getDebugInfo(): String
+
+    /**
+     * Central-role (client/outbound) links only, for [BleRedundantLinkPolicy].
+     * Server/inbound subscriptions are omitted — dual-role same-peer is normal.
+     * Default empty so fakes/mocks do not need to implement it.
+     */
+    fun clientLinkSnapshots(): List<BleClientLinkSnapshot> = emptyList()
 }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
@@ -57,6 +57,13 @@ class BleBearer(
     private var myPeerID: String = myPeerID
     private var nicknameResolver: ((String) -> String?)? = null
 
+    /**
+     * Solicitation gate for inbound RSR (Flags.IS_RSR). Wired by [MeshCoordinator] to
+     * [com.app.transport.sync.RequestSyncManager.isValidResponse]. Default rejects all RSR
+     * (safe until the mesh engine attaches a real registry).
+     */
+    var isValidSyncResponse: (peerID: String) -> Boolean = { false }
+
     // Survives reset(): the new radio stack must inherit the current foreground state.
     private var meshServiceActive: Boolean = false
     private var appIsActive: Boolean = true
@@ -194,6 +201,7 @@ class BleBearer(
                         nowMs = now,
                         maxTimestampSkewMs = radioConfig.ingressMaxTimestampSkewMs,
                         isRSR = packet.isRSR,
+                        isValidSyncResponse = isValidSyncResponse,
                     )
                 ) {
                     is BleIngressPacketGuard.EvaluateResult.Reject -> {
@@ -223,20 +231,22 @@ class BleBearer(
                         try {
                             debugSettingsManager.logIncoming(
                                 packet = packet,
-                                // Log the logical origin; radio hop is in deviceAddress.
-                                fromPeerID = context.validationPeerID,
+                                // Always the claimed logical author; radio hop is in deviceAddress.
+                                fromPeerID = claimedSenderID,
                                 fromNickname = null,
                                 fromDeviceAddress = deviceAddress,
                                 myPeerID = myPeerID,
                             )
                         } catch (_: Exception) {}
-                        // peerID MUST be validationPeerID (claimed logical origin) so
-                        // SecurityManager/Noise use the author key — not the previous hop
-                        // bound on this link (iOS packetContext / handleReceivedPacket split).
+                        // peerID is ALWAYS the claimed logical author (packet.senderID) so
+                        // SecurityManager/Noise verify the author key. For RSR, ingress already
+                        // solicited against validationPeerID (= hop); previousHopPeerID carries
+                        // that hop for any downstream re-check (iOS handleReceivedPacket split:
+                        // hop for link liveness, packet.senderID for crypto).
                         _incoming.trySend(
                             RoutedPacket(
                                 packet = packet,
-                                peerID = context.validationPeerID,
+                                peerID = claimedSenderID,
                                 relayAddress = deviceAddress,
                                 previousHopPeerID = context.receivedFromPeerID,
                             ),
@@ -289,7 +299,7 @@ class BleBearer(
      */
     fun reset(myPeerID: String) {
         val old = connectionManager
-        try { old.stopServices() } catch (_: Exception) {}
+        try { old.shutdown() } catch (_: Exception) {}
         // Detach the old stack's delegate: late asynchronous callbacks must neither emit stale
         // packets into the new generation's flow nor evict fresh address bindings.
         old.delegate = null
@@ -305,7 +315,7 @@ class BleBearer(
     }
 
     override fun start(): Boolean = connectionManager.startServices()
-    override fun stop() = connectionManager.stopServices()
+    override fun stop() = connectionManager.shutdown()
     override fun broadcast(packet: RoutedPacket) = connectionManager.broadcastPacket(packet)
     override fun sendToPeer(peerID: String, packet: RoutedPacket): Boolean =
         connectionManager.sendToPeer(peerID, packet)

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
@@ -223,14 +223,23 @@ class BleBearer(
                         try {
                             debugSettingsManager.logIncoming(
                                 packet = packet,
-                                fromPeerID = context.receivedFromPeerID,
+                                // Log the logical origin; radio hop is in deviceAddress.
+                                fromPeerID = context.validationPeerID,
                                 fromNickname = null,
                                 fromDeviceAddress = deviceAddress,
                                 myPeerID = myPeerID,
                             )
                         } catch (_: Exception) {}
+                        // peerID MUST be validationPeerID (claimed logical origin) so
+                        // SecurityManager/Noise use the author key — not the previous hop
+                        // bound on this link (iOS packetContext / handleReceivedPacket split).
                         _incoming.trySend(
-                            RoutedPacket(packet, context.receivedFromPeerID, deviceAddress),
+                            RoutedPacket(
+                                packet = packet,
+                                peerID = context.validationPeerID,
+                                relayAddress = deviceAddress,
+                                previousHopPeerID = context.receivedFromPeerID,
+                            ),
                         )
                     }
                 }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
@@ -2,7 +2,9 @@
 
 package com.app.transport.mesh
 
+import com.app.common.encoding.toHexString
 import com.app.common.utils.Log
+import com.app.transport.MeshConstants
 import com.app.transport.MeshTelemetry
 import com.app.transport.model.RoutedPacket
 import com.app.transport.protocol.BitchatPacket
@@ -61,6 +63,9 @@ class BleBearer(
 
     // iOS BLEService.lastRedundantLinkRetirementAt — one retirement pass per peer per cooldown.
     private val lastRedundantLinkRetirementAt = mutableMapOf<String, Long>()
+
+    // Short-lived per-packet ingress memory (iOS BLEIngressLinkRegistry).
+    private val ingressRegistry = BleIngressLinkRegistry()
 
     /**
      * The platform radio stack. Replaced in place by [reset]; the BleBearer object keeps its graph
@@ -176,16 +181,59 @@ class BleBearer(
         val cm = connectionManager
         cm.delegate = object : BearerTransportDelegate {
             override fun onPacketReceived(packet: BitchatPacket, peerID: String, deviceAddress: String?) {
-                try {
-                    debugSettingsManager.logIncoming(
+                val claimedSenderID = packet.senderID.toHexString()
+                val boundPeerID = deviceAddress?.let { cm.addressPeerMap[it] }
+                val now = nowMs()
+                when (
+                    val evaluated = BleIngressPacketGuard.evaluate(
                         packet = packet,
-                        fromPeerID = peerID,
-                        fromNickname = null,
-                        fromDeviceAddress = deviceAddress,
-                        myPeerID = myPeerID,
+                        claimedSenderID = claimedSenderID,
+                        boundPeerID = boundPeerID,
+                        localPeerID = myPeerID,
+                        directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
+                        nowMs = now,
+                        maxTimestampSkewMs = radioConfig.ingressMaxTimestampSkewMs,
+                        isRSR = false,
                     )
-                } catch (_: Exception) {}
-                _incoming.trySend(RoutedPacket(packet, peerID, deviceAddress))
+                ) {
+                    is BleIngressPacketGuard.EvaluateResult.Reject -> {
+                        Log.d(
+                            TAG,
+                            "Dropping ingress packet type ${packet.type}: ${evaluated.rejection}",
+                        )
+                        return
+                    }
+                    is BleIngressPacketGuard.EvaluateResult.Accept -> {
+                        val context = evaluated.context
+                        val linkId = when (cm.isClientConnection(deviceAddress ?: "")) {
+                            true -> BleIngressLinkId.Peripheral(deviceAddress ?: "unknown")
+                            false -> BleIngressLinkId.Central(deviceAddress ?: "unknown")
+                            null -> BleIngressLinkId.Peripheral(deviceAddress ?: "unknown")
+                        }
+                        if (!ingressRegistry.recordIfNew(
+                                packet = packet,
+                                link = linkId,
+                                peerID = context.receivedFromPeerID,
+                                nowMs = now,
+                                lifetimeMs = radioConfig.ingressRecordLifetimeMs,
+                            )
+                        ) {
+                            return
+                        }
+                        try {
+                            debugSettingsManager.logIncoming(
+                                packet = packet,
+                                fromPeerID = context.receivedFromPeerID,
+                                fromNickname = null,
+                                fromDeviceAddress = deviceAddress,
+                                myPeerID = myPeerID,
+                            )
+                        } catch (_: Exception) {}
+                        _incoming.trySend(
+                            RoutedPacket(packet, context.receivedFromPeerID, deviceAddress),
+                        )
+                    }
+                }
             }
 
             override fun onDeviceConnected(deviceAddress: String) {
@@ -239,6 +287,7 @@ class BleBearer(
         this.myPeerID = myPeerID
         _neighbors.value = emptySet()
         lastRedundantLinkRetirementAt.clear()
+        ingressRegistry.clear()
         connectionManager = connectionManagerFactory(myPeerID)
         wireConnectionManager()
         nicknameResolver?.let { connectionManager.setNicknameResolver(it) }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
@@ -193,7 +193,7 @@ class BleBearer(
                         directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
                         nowMs = now,
                         maxTimestampSkewMs = radioConfig.ingressMaxTimestampSkewMs,
-                        isRSR = false,
+                        isRSR = packet.isRSR,
                     )
                 ) {
                     is BleIngressPacketGuard.EvaluateResult.Reject -> {

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
@@ -108,6 +108,8 @@ class BleBearer(
                 PeerLink(peerID, linkAddress, isInbound = isInbound)
         }
         retireRedundantClientLinks(peerID = peerID, ingressAddress = linkAddress)
+        // Peer identity on a live link — re-attempt spooled directed traffic (iOS post-announce flush).
+        try { connectionManager.flushDirectedSpool() } catch (_: Exception) {}
     }
 
     private fun notifyPeerDisconnected(deviceAddress: String) {
@@ -193,6 +195,9 @@ class BleBearer(
                     val inbound = cm.isClientConnection(deviceAddress) == false
                     debugSettingsManager.logPeerConnection(peer ?: "unknown", nick, deviceAddress, inbound)
                 } catch (_: Exception) {}
+                // A link just came up — drain directed traffic parked while the radio was empty
+                // (iOS flushDirectedSpool after subscribe/announce).
+                try { cm.flushDirectedSpool() } catch (_: Exception) {}
                 _events.tryEmit(BearerEvent.LinkConnected(deviceAddress))
             }
 

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleBearer.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.app.transport.mesh
 
+import com.app.common.utils.Log
 import com.app.transport.MeshTelemetry
 import com.app.transport.model.RoutedPacket
 import com.app.transport.protocol.BitchatPacket
@@ -13,6 +16,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /**
  * Shared BLE implementation of [MeshBearer]: a single commonMain facade over a platform
@@ -36,9 +41,12 @@ class BleBearer(
     // Ownership predicate for [bindPeer]: returns false for link addresses owned by another bearer
     // (e.g. the `aware:` namespace of the Wi-Fi Aware bearer). Defaults to "owns everything".
     private val ownsLinkAddress: (String) -> Boolean = { true },
+    private val radioConfig: BleRadioConfig = BleRadioConfig(),
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) : MeshBearer, BleDebugHandle {
 
     private companion object {
+        private const val TAG = "BleBearer"
         // Headroom over the old 64-slot SharedFlow buffer: absorbs a handshake burst on entry
         // to a dense zone before DROP_OLDEST starts shedding the stalest frames.
         const val INCOMING_BUFFER_CAPACITY = 256
@@ -50,6 +58,9 @@ class BleBearer(
     // Survives reset(): the new radio stack must inherit the current foreground state.
     private var meshServiceActive: Boolean = false
     private var appIsActive: Boolean = true
+
+    // iOS BLEService.lastRedundantLinkRetirementAt — one retirement pass per peer per cooldown.
+    private val lastRedundantLinkRetirementAt = mutableMapOf<String, Long>()
 
     /**
      * The platform radio stack. Replaced in place by [reset]; the BleBearer object keeps its graph
@@ -84,6 +95,9 @@ class BleBearer(
      * Engine-driven binding of a link address to a logical peerID (announce received with max TTL ⇒
      * direct neighbor). The bearer owns the address↔peer map; addresses owned by another bearer
      * (per [ownsLinkAddress]) are ignored.
+     *
+     * After binding, retires redundant central-role links to the same peer (iOS
+     * [BleRedundantLinkPolicy] parity) so restore/reconnect cannot multiply airtime.
      */
     override fun bindPeer(peerID: String, linkAddress: String) {
         if (!ownsLinkAddress(linkAddress)) return
@@ -93,10 +107,61 @@ class BleBearer(
             links.filterNot { it.deviceAddress == linkAddress }.toSet() +
                 PeerLink(peerID, linkAddress, isInbound = isInbound)
         }
+        retireRedundantClientLinks(peerID = peerID, ingressAddress = linkAddress)
     }
 
     private fun notifyPeerDisconnected(deviceAddress: String) {
         _neighbors.update { links -> links.filterNot { it.deviceAddress == deviceAddress }.toSet() }
+    }
+
+    /**
+     * Central-role duplicate retirement (iOS `BLEService` after verified direct announce).
+     * Only client/outbound links we own are considered; server-role subscriptions stay.
+     */
+    private fun retireRedundantClientLinks(peerID: String, ingressAddress: String) {
+        val now = nowMs()
+        val last = lastRedundantLinkRetirementAt[peerID]
+        if (last != null && now - last < radioConfig.linkRebindCooldownMs) return
+
+        val snapshots = connectionManager.clientLinkSnapshots()
+        if (snapshots.size <= 1) return
+
+        // Reflect the bind we just wrote — platforms read addressPeerMap, but a lagging snapshot
+        // peer field is overwritten from the map when present.
+        val links = snapshots.map { snap ->
+            val boundPeer = connectionManager.addressPeerMap[snap.address] ?: snap.peerID
+            snap.copy(peerID = boundPeer).toPolicyLink()
+        }
+
+        val keptUUID = BleRedundantLinkPolicy.keptPeripheralUUID(
+            ingressPeripheralUUID = ingressAddress,
+            mostRecentlyBoundUUID = ingressAddress,
+            links = links,
+            peerID = peerID,
+        ) ?: return
+
+        val retiring = BleRedundantLinkPolicy.peripheralUUIDsToRetire(
+            links = links,
+            peerID = peerID,
+            keeping = keptUUID,
+        )
+        if (retiring.isEmpty()) return
+
+        lastRedundantLinkRetirementAt[peerID] = now
+        // Survivor is the preferred reverse mapping for directed sends.
+        connectionManager.addressPeerMap[keptUUID] = peerID
+
+        for (uuid in retiring) {
+            // Drop binding before cancel so disconnect callbacks do not treat this as peer leave
+            // (the peer is still live on the kept link).
+            connectionManager.addressPeerMap.remove(uuid)
+            notifyPeerDisconnected(uuid)
+            try {
+                connectionManager.disconnectAddress(uuid)
+            } catch (_: Exception) {
+            }
+            Log.i(TAG, "Retiring redundant client link ${uuid.take(8)}… for peer ${peerID.take(8)}… (keeping ${keptUUID.take(8)}…)")
+        }
     }
 
     init {
@@ -168,6 +233,7 @@ class BleBearer(
         old.delegate = null
         this.myPeerID = myPeerID
         _neighbors.value = emptySet()
+        lastRedundantLinkRetirementAt.clear()
         connectionManager = connectionManagerFactory(myPeerID)
         wireConnectionManager()
         nicknameResolver?.let { connectionManager.setNicknameResolver(it) }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleDirectedRelaySpool.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleDirectedRelaySpool.kt
@@ -1,0 +1,87 @@
+package com.app.transport.mesh
+
+import co.touchlab.stately.concurrency.Lock
+import co.touchlab.stately.concurrency.withLock
+import com.app.transport.protocol.BitchatPacket
+
+/**
+ * Short-lived store for directed packets when this node currently has zero writable BLE links.
+ *
+ * Port of iOS `Services/BLE/BLEDirectedRelaySpool.swift`. Distinct from [StoreForwardManager]
+ * (hours-long offline peer mailbag): this bag lives for seconds and only covers the radio-up race
+ * where a DM/handshake leaves the app before GATT is writable.
+ */
+class BleDirectedRelaySpool {
+    data class Entry(
+        val recipient: String,
+        val packet: BitchatPacket,
+    )
+
+    private data class Stored(
+        val packet: BitchatPacket,
+        val enqueuedAtMs: Long,
+    )
+
+    private val lock = Lock()
+    private val packetsByRecipient = linkedMapOf<String, LinkedHashMap<String, Stored>>()
+
+    val isEmpty: Boolean
+        get() = lock.withLock { packetsByRecipient.isEmpty() }
+
+    val count: Int
+        get() = lock.withLock {
+            packetsByRecipient.values.sumOf { it.size }
+        }
+
+    /**
+     * @return true if newly stored, false if [messageID] was already queued for [recipient].
+     */
+    fun enqueue(
+        packet: BitchatPacket,
+        recipient: String,
+        messageID: String,
+        enqueuedAtMs: Long,
+    ): Boolean = lock.withLock {
+        val packets = packetsByRecipient.getOrPut(recipient) { linkedMapOf() }
+        if (packets.containsKey(messageID)) return false
+        packets[messageID] = Stored(packet, enqueuedAtMs)
+        true
+    }
+
+    /**
+     * Removes every entry and returns those still within [windowMs] of [nowMs].
+     * Callers re-broadcast; if links are still missing, the send path may re-spool.
+     */
+    fun drainUnexpired(nowMs: Long, windowMs: Long): List<Entry> = lock.withLock {
+        val entries = mutableListOf<Entry>()
+        for ((recipient, packets) in packetsByRecipient) {
+            for (stored in packets.values) {
+                if (nowMs - stored.enqueuedAtMs <= windowMs) {
+                    entries.add(Entry(recipient, stored.packet))
+                }
+            }
+        }
+        packetsByRecipient.clear()
+        entries
+    }
+
+    fun pruneExpired(nowMs: Long, windowMs: Long) {
+        lock.withLock {
+            if (packetsByRecipient.isEmpty()) return
+            val pruned = linkedMapOf<String, LinkedHashMap<String, Stored>>()
+            for ((recipient, packets) in packetsByRecipient) {
+                val fresh = linkedMapOf<String, Stored>()
+                for ((id, stored) in packets) {
+                    if (nowMs - stored.enqueuedAtMs <= windowMs) {
+                        fresh[id] = stored
+                    }
+                }
+                if (fresh.isNotEmpty()) pruned[recipient] = fresh
+            }
+            packetsByRecipient.clear()
+            packetsByRecipient.putAll(pruned)
+        }
+    }
+
+    fun clear() = lock.withLock { packetsByRecipient.clear() }
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleFragmentIngressPolicy.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleFragmentIngressPolicy.kt
@@ -1,0 +1,12 @@
+package com.app.transport.mesh
+
+/**
+ * Ingress policy for FRAGMENT packets (iOS BLEFragmentHandler parity for self-replay).
+ *
+ * Self-authored fragments (including RSR after relaunch) must be tracked for gossip
+ * but never assembled — reassembly would only burn fragment-set/byte budgets.
+ */
+internal object BleFragmentIngressPolicy {
+    fun shouldAssemble(authorPeerID: String?, localPeerID: String): Boolean =
+        authorPeerID != null && authorPeerID != localPeerID
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressLinkRegistry.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressLinkRegistry.kt
@@ -97,8 +97,7 @@ class BleIngressLinkRegistry {
         /**
          * Attribute claimed sender vs link-bound peer (iOS packetContext).
          *
-         * @param isRSR Request-Sync Response flag (wire flag not yet on KMP BitchatPacket —
-         *   pass false until BinaryProtocol carries Flags.IS_RSR).
+         * @param isRSR Request-Sync Response flag (wire Flags.IS_RSR / [BitchatPacket.isRSR]).
          */
         fun packetContext(
             packet: BitchatPacket,

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressLinkRegistry.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressLinkRegistry.kt
@@ -45,6 +45,8 @@ class BleIngressLinkRegistry {
     val isEmpty: Boolean
         get() = lock.withLock { ingressByMessageID.isEmpty() }
 
+    internal fun debugRecordCount(): Int = lock.withLock { ingressByMessageID.size }
+
     fun clear() = lock.withLock { ingressByMessageID.clear() }
 
     fun record(forPacket: BitchatPacket): BleIngressLinkRecord? = lock.withLock {
@@ -67,13 +69,23 @@ class BleIngressLinkRegistry {
         if (existing != null && nowMs - existing.timestampMs <= lifetimeMs) {
             return false
         }
+        // An expired sighting is a new FIFO insertion. Plain assignment would retain the old
+        // LinkedHashMap position and make the refreshed record the next eviction candidate.
+        if (existing != null) ingressByMessageID.remove(id)
         ingressByMessageID[id] = BleIngressLinkRecord(link, peerID, nowMs)
-        // Bound growth: drop entries older than lifetime when map is large.
+        // Hard cap: first drop expired, then FIFO-evict oldest insertions until under MAX_RECORDS.
+        // (Previously only expired entries were removed, so all-fresh maps could grow unbounded.)
         if (ingressByMessageID.size > MAX_RECORDS) {
             val cutoff = nowMs - lifetimeMs
             val it = ingressByMessageID.entries.iterator()
             while (it.hasNext()) {
                 if (it.next().value.timestampMs < cutoff) it.remove()
+            }
+            while (ingressByMessageID.size > MAX_RECORDS) {
+                val oldest = ingressByMessageID.entries.iterator()
+                if (!oldest.hasNext()) break
+                oldest.next()
+                oldest.remove()
             }
         }
         true
@@ -107,7 +119,9 @@ class BleIngressLinkRegistry {
             directAnnounceTTL: UByte,
             isRSR: Boolean = false,
         ): Result {
-            if (claimedSenderID == localPeerID && !(isRSR && packet.ttl == 0u.toUByte())) {
+            if (claimedSenderID == localPeerID &&
+                !isSelfAuthoredSyncResponse(packet, claimedSenderID, localPeerID)
+            ) {
                 return Result.Failure(BleIngressRejection.SelfLoopback(packet.type))
             }
 
@@ -139,6 +153,20 @@ class BleIngressLinkRegistry {
 
         fun isDirectAnnounce(packet: BitchatPacket, directAnnounceTTL: UByte): Boolean =
             packet.type == MessageType.ANNOUNCE.value && packet.ttl == directAnnounceTTL
+
+        /**
+         * Neighbor returned our own stored packet as a solicited RSR after relaunch/reset
+         * (iOS `isSelfAuthoredSyncResponse`: isRSR && ttl==0 && sender==local).
+         * Normal self-loopback (non-RSR or ttl>0) must still be rejected.
+         */
+        fun isSelfAuthoredSyncResponse(
+            packet: BitchatPacket,
+            claimedSenderID: String,
+            localPeerID: String,
+        ): Boolean =
+            claimedSenderID == localPeerID &&
+                packet.isRSR &&
+                packet.ttl == 0u.toUByte()
 
         private fun requiresDirectSenderBinding(packet: BitchatPacket): Boolean =
             packet.type == MessageType.REQUEST_SYNC.value

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressLinkRegistry.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressLinkRegistry.kt
@@ -1,0 +1,152 @@
+package com.app.transport.mesh
+
+import co.touchlab.stately.concurrency.Lock
+import co.touchlab.stately.concurrency.withLock
+import com.app.common.encoding.hexEncodedString
+import com.app.transport.crypto.Sha256
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+
+/**
+ * Ingress link memory and packet-context attribution — port of iOS
+ * `Services/BLE/BLEIngressLinkRegistry.swift`.
+ *
+ * [messageId] is the local-only dedup key shared with [SecurityManager]
+ * (sender-timestamp-type-sha256(payload).prefix(4)).
+ */
+sealed class BleIngressLinkId {
+    data class Peripheral(val address: String) : BleIngressLinkId()
+    data class Central(val address: String) : BleIngressLinkId()
+}
+
+data class BleIngressPacketContext(
+    val receivedFromPeerID: String,
+    val validationPeerID: String,
+)
+
+data class BleIngressLinkRecord(
+    val link: BleIngressLinkId,
+    val peerID: String,
+    val timestampMs: Long,
+)
+
+sealed class BleIngressRejection {
+    data class SelfLoopback(val packetType: UByte) : BleIngressRejection()
+    data class DirectSenderMismatch(
+        val boundPeerID: String,
+        val claimedSenderID: String,
+    ) : BleIngressRejection()
+}
+
+class BleIngressLinkRegistry {
+    private val lock = Lock()
+    private val ingressByMessageID = linkedMapOf<String, BleIngressLinkRecord>()
+
+    val isEmpty: Boolean
+        get() = lock.withLock { ingressByMessageID.isEmpty() }
+
+    fun clear() = lock.withLock { ingressByMessageID.clear() }
+
+    fun record(forPacket: BitchatPacket): BleIngressLinkRecord? = lock.withLock {
+        ingressByMessageID[messageId(forPacket)]
+    }
+
+    /**
+     * @return true if this is the first sighting within [lifetimeMs], false if a recent
+     * duplicate on any link (caller should drop).
+     */
+    fun recordIfNew(
+        packet: BitchatPacket,
+        link: BleIngressLinkId,
+        peerID: String,
+        nowMs: Long,
+        lifetimeMs: Long,
+    ): Boolean = lock.withLock {
+        val id = messageId(packet)
+        val existing = ingressByMessageID[id]
+        if (existing != null && nowMs - existing.timestampMs <= lifetimeMs) {
+            return false
+        }
+        ingressByMessageID[id] = BleIngressLinkRecord(link, peerID, nowMs)
+        // Bound growth: drop entries older than lifetime when map is large.
+        if (ingressByMessageID.size > MAX_RECORDS) {
+            val cutoff = nowMs - lifetimeMs
+            val it = ingressByMessageID.entries.iterator()
+            while (it.hasNext()) {
+                if (it.next().value.timestampMs < cutoff) it.remove()
+            }
+        }
+        true
+    }
+
+    fun prune(beforeMs: Long) = lock.withLock {
+        val it = ingressByMessageID.entries.iterator()
+        while (it.hasNext()) {
+            if (it.next().value.timestampMs < beforeMs) it.remove()
+        }
+    }
+
+    companion object {
+        private const val MAX_RECORDS = 4096
+
+        fun messageId(packet: BitchatPacket): String {
+            val digestPrefix = Sha256.digest(packet.payload).copyOf(4).hexEncodedString()
+            return "${packet.senderID.hexEncodedString()}-${packet.timestamp}-${packet.type}-$digestPrefix"
+        }
+
+        /**
+         * Attribute claimed sender vs link-bound peer (iOS packetContext).
+         *
+         * @param isRSR Request-Sync Response flag (wire flag not yet on KMP BitchatPacket —
+         *   pass false until BinaryProtocol carries Flags.IS_RSR).
+         */
+        fun packetContext(
+            packet: BitchatPacket,
+            claimedSenderID: String,
+            boundPeerID: String?,
+            localPeerID: String,
+            directAnnounceTTL: UByte,
+            isRSR: Boolean = false,
+        ): Result {
+            if (claimedSenderID == localPeerID && !(isRSR && packet.ttl == 0u.toUByte())) {
+                return Result.Failure(BleIngressRejection.SelfLoopback(packet.type))
+            }
+
+            if (boundPeerID != null && boundPeerID != claimedSenderID) {
+                if (requiresDirectSenderBinding(packet)) {
+                    return Result.Failure(
+                        BleIngressRejection.DirectSenderMismatch(boundPeerID, claimedSenderID),
+                    )
+                }
+                if (isDirectAnnounce(packet, directAnnounceTTL)) {
+                    return Result.Success(
+                        BleIngressPacketContext(
+                            receivedFromPeerID = claimedSenderID,
+                            validationPeerID = claimedSenderID,
+                        ),
+                    )
+                }
+            }
+
+            val receivedFromPeerID = boundPeerID ?: claimedSenderID
+            val validationPeerID = if (isRSR) receivedFromPeerID else claimedSenderID
+            return Result.Success(
+                BleIngressPacketContext(
+                    receivedFromPeerID = receivedFromPeerID,
+                    validationPeerID = validationPeerID,
+                ),
+            )
+        }
+
+        fun isDirectAnnounce(packet: BitchatPacket, directAnnounceTTL: UByte): Boolean =
+            packet.type == MessageType.ANNOUNCE.value && packet.ttl == directAnnounceTTL
+
+        private fun requiresDirectSenderBinding(packet: BitchatPacket): Boolean =
+            packet.type == MessageType.REQUEST_SYNC.value
+
+        sealed class Result {
+            data class Success(val context: BleIngressPacketContext) : Result()
+            data class Failure(val rejection: BleIngressRejection) : Result()
+        }
+    }
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressPacketGuard.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleIngressPacketGuard.kt
@@ -1,0 +1,108 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+
+/**
+ * First-line ingress validation before mesh security/signature work — port of iOS
+ * `Services/BLE/BLEIngressPacketGuard.swift`.
+ *
+ * Composes [BleIngressLinkRegistry.packetContext] with payload checks (RSR gate, clock skew).
+ */
+object BleIngressPacketGuard {
+    /** iOS BLEIngressPacketGuard default maxTimestampSkewMs. */
+    const val DEFAULT_MAX_TIMESTAMP_SKEW_MS: Long = 120_000L
+
+    sealed class Rejection {
+        data class SelfLoopback(val packetType: UByte) : Rejection()
+        data class DirectSenderMismatch(
+            val boundPeerID: String,
+            val claimedSenderID: String,
+        ) : Rejection()
+        data class InvalidRSR(val peerID: String) : Rejection()
+        data class TimestampSkew(
+            val peerID: String,
+            val skewMs: Long,
+            val maxSkewMs: Long,
+        ) : Rejection()
+    }
+
+    sealed class EvaluateResult {
+        data class Accept(val context: BleIngressPacketContext) : EvaluateResult()
+        data class Reject(val rejection: Rejection) : EvaluateResult()
+    }
+
+    fun evaluate(
+        packet: BitchatPacket,
+        claimedSenderID: String,
+        boundPeerID: String?,
+        localPeerID: String,
+        directAnnounceTTL: UByte,
+        nowMs: Long,
+        maxTimestampSkewMs: Long = DEFAULT_MAX_TIMESTAMP_SKEW_MS,
+        isRSR: Boolean = false,
+        isValidSyncResponse: (peerID: String) -> Boolean = { false },
+    ): EvaluateResult {
+        when (
+            val contextResult = BleIngressLinkRegistry.packetContext(
+                packet = packet,
+                claimedSenderID = claimedSenderID,
+                boundPeerID = boundPeerID,
+                localPeerID = localPeerID,
+                directAnnounceTTL = directAnnounceTTL,
+                isRSR = isRSR,
+            )
+        ) {
+            is BleIngressLinkRegistry.Companion.Result.Failure -> {
+                return EvaluateResult.Reject(
+                    when (val r = contextResult.rejection) {
+                        is BleIngressRejection.SelfLoopback ->
+                            Rejection.SelfLoopback(r.packetType)
+                        is BleIngressRejection.DirectSenderMismatch ->
+                            Rejection.DirectSenderMismatch(r.boundPeerID, r.claimedSenderID)
+                    },
+                )
+            }
+            is BleIngressLinkRegistry.Companion.Result.Success -> {
+                val payloadResult = validatePayload(
+                    packet = packet,
+                    peerID = contextResult.context.validationPeerID,
+                    nowMs = nowMs,
+                    maxTimestampSkewMs = maxTimestampSkewMs,
+                    isRSR = isRSR,
+                    isValidSyncResponse = isValidSyncResponse,
+                )
+                return when (payloadResult) {
+                    null -> EvaluateResult.Accept(contextResult.context)
+                    else -> EvaluateResult.Reject(payloadResult)
+                }
+            }
+        }
+    }
+
+    /**
+     * @return null when payload is acceptable, otherwise a rejection.
+     */
+    fun validatePayload(
+        packet: BitchatPacket,
+        peerID: String,
+        nowMs: Long,
+        maxTimestampSkewMs: Long = DEFAULT_MAX_TIMESTAMP_SKEW_MS,
+        isRSR: Boolean = false,
+        isValidSyncResponse: (peerID: String) -> Boolean = { false },
+    ): Rejection? {
+        if (isRSR) {
+            return if (isValidSyncResponse(peerID)) {
+                null
+            } else {
+                Rejection.InvalidRSR(peerID)
+            }
+        }
+
+        val packetTime = packet.timestamp.toLong()
+        val skew = if (packetTime > nowMs) packetTime - nowMs else nowMs - packetTime
+        if (skew > maxTimestampSkewMs) {
+            return Rejection.TimestampSkew(peerID, skew, maxTimestampSkewMs)
+        }
+        return null
+    }
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleLinkOutboundBuffer.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleLinkOutboundBuffer.kt
@@ -65,8 +65,9 @@ internal class BleLinkOutboundBuffer(
             while (i < chunks.size) {
                 when (writer.writeChunk(chunks[i])) {
                     ChunkWriteResult.SENT -> i++
-                    // link died mid/at-start; head (if any) is gone, nothing to queue.
-                    ChunkWriteResult.GONE -> return@withLock true
+                    // Link died mid/at-start: report failure so the send path can spool or flood.
+                    // (Previously returned true, so directed frames were treated as delivered and lost.)
+                    ChunkWriteResult.GONE -> return@withLock false
                     ChunkWriteResult.BUSY -> {
                         // Stash the tail (chunks i..end); this frame's head already went out, so it
                         // is now the in-flight "started" frame — it must never be dropped.

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleNoiseSessionQueues.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleNoiseSessionQueues.kt
@@ -79,6 +79,20 @@ class BleNoiseSessionQueues(
         queue.toList()
     }
 
+    fun prependTypedPayloads(payloads: List<ByteArray>, peerID: String) {
+        lock.withLock {
+            if (payloads.isEmpty()) return
+            ensurePeerCapacity(typedPayloadsByPeerID)
+            val queue = typedPayloadsByPeerID.getOrPut(peerID) { ArrayDeque() }
+            for (i in payloads.indices.reversed()) {
+                queue.addFirst(payloads[i].copyOf())
+            }
+            while (queue.size > maxTypedPayloadsPerPeer) {
+                queue.removeLast()
+            }
+        }
+    }
+
     private fun <T> ensurePeerCapacity(map: LinkedHashMap<String, ArrayDeque<T>>) {
         while (map.size >= maxPeers && map.isNotEmpty()) {
             val eldest = map.entries.first().key

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleNoiseSessionQueues.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleNoiseSessionQueues.kt
@@ -1,0 +1,94 @@
+package com.app.transport.mesh
+
+import co.touchlab.stately.concurrency.Lock
+import co.touchlab.stately.concurrency.withLock
+
+/**
+ * Pending Noise traffic held until a session with a peer is established.
+ *
+ * Port of iOS `Services/BLE/BLENoiseSessionQueues.swift`. Without this, a first DM (or a typed
+ * Noise payload such as a receipt/verify/vouch) issued before the XX handshake finishes is dropped
+ * on the floor after `initiateHandshake`.
+ *
+ * Caps are defensive (iOS is unbounded under the collections queue); oldest entries drop when a
+ * per-peer or peer-count limit is hit so a handshake flood cannot grow the bag without bound.
+ */
+class BleNoiseSessionQueues(
+    private val maxPrivateMessagesPerPeer: Int = DEFAULT_MAX_PRIVATE_PER_PEER,
+    private val maxTypedPayloadsPerPeer: Int = DEFAULT_MAX_TYPED_PER_PEER,
+    private val maxPeers: Int = DEFAULT_MAX_PEERS,
+) {
+    data class PendingPrivateMessage(
+        val content: String,
+        val messageID: String,
+    )
+
+    private val lock = Lock()
+    private val privateMessagesByPeerID = linkedMapOf<String, ArrayDeque<PendingPrivateMessage>>()
+    private val typedPayloadsByPeerID = linkedMapOf<String, ArrayDeque<ByteArray>>()
+
+    val isEmpty: Boolean
+        get() = lock.withLock {
+            privateMessagesByPeerID.isEmpty() && typedPayloadsByPeerID.isEmpty()
+        }
+
+    fun clear() = lock.withLock {
+        privateMessagesByPeerID.clear()
+        typedPayloadsByPeerID.clear()
+    }
+
+    fun appendPrivateMessage(content: String, messageID: String, peerID: String) = lock.withLock {
+        ensurePeerCapacity(privateMessagesByPeerID)
+        val queue = privateMessagesByPeerID.getOrPut(peerID) { ArrayDeque() }
+        if (queue.size >= maxPrivateMessagesPerPeer) {
+            queue.removeFirst()
+        }
+        queue.addLast(PendingPrivateMessage(content, messageID))
+    }
+
+    fun takePrivateMessages(peerID: String): List<PendingPrivateMessage> = lock.withLock {
+        val queue = privateMessagesByPeerID.remove(peerID) ?: return emptyList()
+        queue.toList()
+    }
+
+    fun prependPrivateMessages(messages: List<PendingPrivateMessage>, peerID: String) {
+        lock.withLock {
+            if (messages.isEmpty()) return
+            ensurePeerCapacity(privateMessagesByPeerID)
+            val queue = privateMessagesByPeerID.getOrPut(peerID) { ArrayDeque() }
+            for (i in messages.indices.reversed()) {
+                queue.addFirst(messages[i])
+            }
+            while (queue.size > maxPrivateMessagesPerPeer) {
+                queue.removeLast()
+            }
+        }
+    }
+
+    fun appendTypedPayload(payload: ByteArray, peerID: String) = lock.withLock {
+        ensurePeerCapacity(typedPayloadsByPeerID)
+        val queue = typedPayloadsByPeerID.getOrPut(peerID) { ArrayDeque() }
+        if (queue.size >= maxTypedPayloadsPerPeer) {
+            queue.removeFirst()
+        }
+        queue.addLast(payload.copyOf())
+    }
+
+    fun takeTypedPayloads(peerID: String): List<ByteArray> = lock.withLock {
+        val queue = typedPayloadsByPeerID.remove(peerID) ?: return emptyList()
+        queue.toList()
+    }
+
+    private fun <T> ensurePeerCapacity(map: LinkedHashMap<String, ArrayDeque<T>>) {
+        while (map.size >= maxPeers && map.isNotEmpty()) {
+            val eldest = map.entries.first().key
+            map.remove(eldest)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_PRIVATE_PER_PEER = 32
+        const val DEFAULT_MAX_TYPED_PER_PEER = 32
+        const val DEFAULT_MAX_PEERS = 64
+    }
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
@@ -56,4 +56,8 @@ data class BleRadioConfig(
 
     // --- directed spool when no writable links (iOS bleDirectedSpoolWindowSeconds) ---
     val directedSpoolWindowMs: Long = 60_000L,
+
+    // --- ingress (iOS bleIngressRecordLifetimeSeconds / BLEIngressPacketGuard skew) ---
+    val ingressRecordLifetimeMs: Long = 3_000L,
+    val ingressMaxTimestampSkewMs: Long = 120_000L,
 )

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
@@ -49,4 +49,8 @@ data class BleRadioConfig(
     val dutyOffMs: Long = 10_000L,
     val dutyOnDenseMs: Long = 3_000L,
     val dutyOffDenseMs: Long = 15_000L,
+
+    // --- redundant central-role link retirement (iOS bleLinkRebindCooldownSeconds) ---
+    /** At most one redundant-link retirement pass per peer per this window. */
+    val linkRebindCooldownMs: Long = 60_000L,
 )

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
@@ -53,4 +53,7 @@ data class BleRadioConfig(
     // --- redundant central-role link retirement (iOS bleLinkRebindCooldownSeconds) ---
     /** At most one redundant-link retirement pass per peer per this window. */
     val linkRebindCooldownMs: Long = 60_000L,
+
+    // --- directed spool when no writable links (iOS bleDirectedSpoolWindowSeconds) ---
+    val directedSpoolWindowMs: Long = 60_000L,
 )

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRadioConfig.kt
@@ -1,5 +1,11 @@
 package com.app.transport.mesh
 
+/** Stable IDs used by the native app and KMP CoreBluetooth state restoration. */
+internal object CoreBluetoothRestoreIds {
+    const val CENTRAL = "chat.bitchat.ble.central"
+    const val PERIPHERAL = "chat.bitchat.ble.peripheral"
+}
+
 /**
  * commonMain parity copy of the reference iOS `TransportConfig` BLE knobs (values verified against
  * `bitchat/bitchat-ios/bitchat/Services/TransportConfig.swift`). Kept as one place both platforms

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRedundantLinkPolicy.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleRedundantLinkPolicy.kt
@@ -1,0 +1,84 @@
+package com.app.transport.mesh
+
+/**
+ * Decides which central-role (client) connections are redundant duplicates of a peer's live link.
+ *
+ * Port of iOS `Services/BLE/BLERedundantLinkPolicy.swift`.
+ *
+ * One connection per role per peer is the normal dual-role topology (each device is both central and
+ * peripheral). After BLE state restoration the same phone can reappear under a fresh peripheral
+ * address while a restored connection lives on — leaving several live central-role connections to
+ * one peer, each carrying every packet (field-verified: 2–3× airtime). Only same-role (client)
+ * duplicates are retired; the peer's server-role subscription on our peripheral manager is its own
+ * connection to manage.
+ */
+object BleRedundantLinkPolicy {
+
+    data class PeripheralLink(
+        val uuid: String,
+        val peerID: String?,
+        val isConnected: Boolean,
+        /**
+         * Whether the link has a discovered characteristic (is writable).
+         * A link mid-service-rediscovery must never be kept over a writable duplicate.
+         */
+        val hasCharacteristic: Boolean,
+    )
+
+    /**
+     * The link to keep when a peer has several connected bound client links, or null when there is
+     * nothing to consolidate. Prefers the ingress link of the verified direct announce that
+     * triggered the check (the strongest liveness proof available), falling back to the peer's most
+     * recently bound link — but only among writable links while any exist. When neither anchor is a
+     * viable candidate, consolidation waits for a later announce rather than guessing.
+     */
+    fun keptPeripheralUUID(
+        ingressPeripheralUUID: String?,
+        mostRecentlyBoundUUID: String?,
+        links: List<PeripheralLink>,
+        peerID: String,
+    ): String? {
+        val bound = links.filter { it.peerID == peerID && it.isConnected }
+        if (bound.size <= 1) return null
+
+        val writable = bound.filter { it.hasCharacteristic }
+        val candidates = if (writable.isEmpty()) bound else writable
+
+        if (ingressPeripheralUUID != null && candidates.any { it.uuid == ingressPeripheralUUID }) {
+            return ingressPeripheralUUID
+        }
+        if (mostRecentlyBoundUUID != null && candidates.any { it.uuid == mostRecentlyBoundUUID }) {
+            return mostRecentlyBoundUUID
+        }
+        return null
+    }
+
+    /** Connected client links bound to [peerID] other than the kept one. */
+    fun peripheralUUIDsToRetire(
+        links: List<PeripheralLink>,
+        peerID: String,
+        keeping: String,
+    ): List<String> =
+        links
+            .filter { it.peerID == peerID && it.isConnected && it.uuid != keeping }
+            .map { it.uuid }
+}
+
+/**
+ * Snapshot of one central-role (client) link for [BleRedundantLinkPolicy].
+ * Addresses are opaque platform strings (Android MAC / iOS NSUUID).
+ */
+data class BleClientLinkSnapshot(
+    val address: String,
+    val peerID: String?,
+    val isConnected: Boolean,
+    val hasCharacteristic: Boolean,
+) {
+    fun toPolicyLink(): BleRedundantLinkPolicy.PeripheralLink =
+        BleRedundantLinkPolicy.PeripheralLink(
+            uuid = address,
+            peerID = peerID,
+            isConnected = isConnected,
+            hasCharacteristic = hasCharacteristic,
+        )
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSelfBroadcastTracker.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSelfBroadcastTracker.kt
@@ -1,0 +1,53 @@
+package com.app.transport.mesh
+
+import co.touchlab.stately.concurrency.Lock
+import co.touchlab.stately.concurrency.withLock
+import com.app.common.encoding.toHexString
+import com.app.transport.protocol.BitchatPacket
+
+/** One-shot mapping from a relayed self-broadcast to the local timeline UUID. */
+internal class BleSelfBroadcastTracker(
+    private val capacity: Int = DEFAULT_CAPACITY,
+) {
+    private data class Entry(val messageID: String, val sentAtMillis: Long)
+
+    private val lock = Lock()
+    private val entriesByDedupID = linkedMapOf<String, Entry>()
+
+    init {
+        require(capacity > 0)
+    }
+
+    fun record(messageID: String, packet: BitchatPacket, sentAtMillis: Long): Unit = lock.withLock {
+        val key = dedupID(packet)
+        entriesByDedupID.remove(key)
+        entriesByDedupID[key] = Entry(messageID, sentAtMillis)
+        while (entriesByDedupID.size > capacity) {
+            entriesByDedupID.remove(entriesByDedupID.keys.first())
+        }
+    }
+
+    fun takeMessageID(packet: BitchatPacket): String? = lock.withLock {
+        entriesByDedupID.remove(dedupID(packet))?.messageID
+    }
+
+    fun prune(beforeMillis: Long): Unit = lock.withLock {
+        val iterator = entriesByDedupID.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().value.sentAtMillis < beforeMillis) iterator.remove()
+        }
+    }
+
+    fun clear(): Unit = lock.withLock {
+        entriesByDedupID.clear()
+    }
+
+    internal fun debugCount(): Int = lock.withLock { entriesByDedupID.size }
+
+    private fun dedupID(packet: BitchatPacket): String =
+        "${packet.senderID.toHexString()}-${packet.timestamp}-${packet.type}"
+
+    private companion object {
+        const val DEFAULT_CAPACITY = 1_000
+    }
+}

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSendCore.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSendCore.kt
@@ -1,9 +1,12 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.app.transport.mesh
 
 import com.app.common.encoding.toHexString
 import com.app.common.utils.Log
 import com.app.transport.MeshTrafficLog
 import com.app.transport.model.RoutedPacket
+import com.app.transport.protocol.BitchatPacket
 import com.app.transport.protocol.MessageType
 import com.app.transport.protocol.SpecialRecipients
 import com.app.transport.sync.PacketIdUtil
@@ -11,6 +14,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /** One BLE link the local node can write to right now. */
 data class BleNeighbor(
@@ -69,6 +74,7 @@ class BleSendCore(
     private val sourceRoutingEnabled: Boolean,
     private val logTag: String,
     private val config: BleRadioConfig = BleRadioConfig(),
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     private var nicknameResolver: ((String) -> String?)? = null
 
@@ -82,6 +88,9 @@ class BleSendCore(
     private val sendQueue = BleOutboundFrameQueue(config.sendQueueCapacity) {
         trafficLog?.onOutboundDropped(BearerId.BLE)
     }
+
+    /** Short-lived directed bag while the radio has zero writable neighbors (iOS BLEDirectedRelaySpool). */
+    private val directedSpool = BleDirectedRelaySpool()
 
     init {
         scope.launch {
@@ -113,9 +122,14 @@ class BleSendCore(
      */
     fun sendToPeer(targetPeerID: String, routed: RoutedPacket): Boolean {
         val packet = routed.packet
+        val neighbors = radio.neighbors()
+        if (neighbors.isEmpty()) {
+            spoolIfDirected(packet, directedPeerID = targetPeerID)
+            return false
+        }
         // iOS-compatible: only Noise frames are padded over BLE (BLEPacketPaddingPolicy).
         val data = packet.toBinaryData(padding = BLEPacketPaddingPolicy.shouldPadForBLE(packet.type)) ?: return false
-        for (neighbor in radio.neighbors()) {
+        for (neighbor in neighbors) {
             if (neighbor.peerID != targetPeerID) continue
             if (radio.writeToNeighbor(neighbor, data)) {
                 logPacketRelay(routed, toPeer = targetPeerID, toAddress = neighbor.linkAddress)
@@ -125,7 +139,25 @@ class BleSendCore(
         return false
     }
 
+    /**
+     * Drain directed packets held while no links were writable (call on link-up / subscribe).
+     * Re-broadcasts unexpired entries; if links are still missing the send path re-spools them.
+     */
+    fun flushDirectedSpool() {
+        val toSend = directedSpool.drainUnexpired(nowMs(), config.directedSpoolWindowMs)
+        if (toSend.isEmpty()) return
+        Log.d(logTag, "🧳 Flushing ${toSend.size} directed spool packet(s)")
+        for (entry in toSend) {
+            broadcastPacket(RoutedPacket(entry.packet, directedPeerID = entry.recipient))
+        }
+    }
+
+    fun pruneDirectedSpool() {
+        directedSpool.pruneExpired(nowMs(), config.directedSpoolWindowMs)
+    }
+
     fun shutdown() {
+        directedSpool.clear()
         sendQueue.close()
     }
 
@@ -149,12 +181,21 @@ class BleSendCore(
         val senderID = packet.senderID.toHexString()
         val routeInfo = packet.route?.takeIf { it.isNotEmpty() }?.let { "routed: ${it.size} hops" }
         val neighbors = radio.neighbors()
+        val directedTarget = routed.directedPeerID
+            ?: packet.recipientID
+                ?.takeIf { !it.contentEquals(SpecialRecipients.BROADCAST) }
+                ?.toHexString()
+
+        // No writable links: park directed traffic briefly instead of dropping (iOS spool).
+        if (neighbors.isEmpty()) {
+            spoolIfDirected(packet, directedPeerID = directedTarget)
+            return
+        }
 
         // Queued directed send (gossip-sync responses): deliver only to the target peer's
         // link. If the link is gone, fall through to the broadcast fallback below — the
         // same historical fallback MeshNetwork.sendToPeer uses on the direct path.
-        val directedTarget = routed.directedPeerID
-        if (directedTarget != null) {
+        if (directedTarget != null && routed.directedPeerID != null) {
             for (neighbor in neighbors) {
                 if (neighbor.peerID != directedTarget) continue
                 if (radio.writeToNeighbor(neighbor, data)) {
@@ -212,6 +253,19 @@ class BleSendCore(
             if (radio.writeToNeighbor(neighbor, data)) {
                 logPacketRelay(routed, neighbor.peerID, neighbor.linkAddress, packet.version, routeInfo)
             }
+        }
+    }
+
+    private fun spoolIfDirected(packet: BitchatPacket, directedPeerID: String?) {
+        // Broadcast traffic has no single recipient to park for.
+        val recipient = directedPeerID
+            ?: packet.recipientID
+                ?.takeIf { !it.contentEquals(SpecialRecipients.BROADCAST) }
+                ?.toHexString()
+            ?: return
+        val messageID = PacketIdUtil.computeIdHex(packet)
+        if (directedSpool.enqueue(packet, recipient, messageID, nowMs())) {
+            Log.d(logTag, "🧳 Spooling directed packet for ${recipient.take(8)}… mid=${messageID.take(8)}…")
         }
     }
 

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSendCore.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSendCore.kt
@@ -52,8 +52,9 @@ interface BleRadioLink {
  * Owns, once, in commonMain:
  *  - fragmentation, inter-fragment pacing, transfer progress and cancel ([FragmentingPacketSender]),
  *  - `toBinaryData(padding = shouldPadForBLE(type))` — the iOS-compatible wire encoding,
- *  - source routing for originating packets (behind [sourceRoutingEnabled]: the Apple bearer never
- *    had it, so it stays off there until the owner enables it deliberately),
+ *  - source routing for originating packets (behind [sourceRoutingEnabled]; both Android and
+ *    CoreBluetooth enable this so multi-hop directed unicast can attach routes when the graph
+ *    has confirmed edges — empty routes still flood),
  *  - directed-send-to-neighbor with broadcast fallback,
  *  - broadcast with relay/sender anti-loop,
  *  - per-target relay telemetry through the [MeshTrafficLog] port (null = silent, Apple today).

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSendCore.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/BleSendCore.kt
@@ -224,12 +224,20 @@ class BleSendCore(
         val recipientID = packet.recipientID
         if (recipientID != null && !recipientID.contentEquals(SpecialRecipients.BROADCAST)) {
             val recipient = recipientID.toHexString()
+            var directedWriteFailed = false
             for (neighbor in neighbors) {
                 if (neighbor.peerID != recipient) continue
                 if (radio.writeToNeighbor(neighbor, data)) {
                     logPacketRelay(routed, neighbor.peerID, neighbor.linkAddress, packet.version, routeInfo)
                     return
                 }
+                directedWriteFailed = true
+            }
+            // Neighbor present but every write returned false (GONE/error) — park directed
+            // traffic instead of falling into a flood that may also fail silently (P0.6).
+            if (directedWriteFailed) {
+                spoolIfDirected(packet, directedPeerID = recipient)
+                return
             }
         }
 

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/FragmentManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/FragmentManager.kt
@@ -10,20 +10,16 @@ import com.app.common.utils.Log
 import com.app.transport.MeshConstants
 import com.app.transport.protocol.BitchatPacket
 import com.app.transport.protocol.MessageType
-import com.app.transport.protocol.MessagePadding
 import com.app.transport.model.FragmentPayload
 import kotlinx.coroutines.*
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /**
- * Manages message fragmentation and reassembly - 100% iOS Compatible
- * 
- * This implementation exactly matches iOS SimplifiedBluetoothService fragmentation:
- * - Same fragment payload structure (13-byte header + data)
- * - Same MTU thresholds and fragment sizes
- * - Same reassembly logic and timeout handling
- * - Uses new FragmentPayload model for type safety
+ * Message fragmentation and reassembly for BLE MTU.
+ *
+ * Wire-compatible with iOS SimplifiedBluetoothService fragmentation:
+ * 13-byte fragment header, ~512 MTU threshold, bounded reassembly budgets.
  */
 class FragmentManager(
     dispatchers: AppDispatchers = AppDispatchers(),
@@ -58,27 +54,20 @@ class FragmentManager(
     }
     
     /**
-     * Create fragments from a large packet - 100% iOS Compatible
-     * Matches iOS sendFragmentedPacket() implementation exactly
+     * Create fragments from a large packet (iOS sendFragmentedPacket shape).
      */
     fun createFragments(packet: BitchatPacket): List<BitchatPacket> {
         try {
             Log.d(TAG, "🔀 Creating fragments for packet type ${packet.type}, payload: ${packet.payload.size} bytes")
-        val encoded = packet.toBinaryData()
-            if (encoded == null) {
+        // Fragment the raw binary frame without PKCS#7 pad. For large packets encode()
+        // already skips block padding; calling MessagePadding.unpad on unpadded data can
+        // strip real trailing signature bytes that look like valid PKCS#7 (false positive).
+        val fullData = packet.toBinaryData(padding = false)
+            if (fullData == null) {
                 Log.e(TAG, "❌ Failed to encode packet to binary data")
                 return emptyList()
             }
-            Log.d(TAG, "📦 Encoded to ${encoded.size} bytes")
-        
-        // Fragment the unpadded frame; each fragment will be encoded (and padded) independently - iOS fix
-        val fullData = try {
-                MessagePadding.unpad(encoded)
-            } catch (e: Exception) {
-                Log.e(TAG, "❌ Failed to unpad data: ${e.message}", e)
-                return emptyList()
-            }
-            Log.d(TAG, "📏 Unpadded to ${fullData.size} bytes")
+            Log.d(TAG, "📦 Encoded to ${fullData.size} bytes (no pad; fragments pad independently)")
         
         // iOS logic: if data.count > 512 && packet.type != MessageType.fragment.rawValue
         if (fullData.size <= FRAGMENT_SIZE_THRESHOLD) {
@@ -135,7 +124,9 @@ class FragmentManager(
             )
             
             // iOS: MessageType.fragment.rawValue (single fragment type)
-            // Fix: Fragments must inherit source route and use v2 if routed
+            // Fix: Fragments must inherit source route and use v2 if routed.
+            // isRSR must be copied so gossip-replay fragments of old RSR packets still
+            // skip the 120s clock-skew gate (iOS BLEOutboundFragmentPlanner parity).
             val fragmentPacket = BitchatPacket(
                 version = if (packet.route != null) 2u else 1u,
                 type = MessageType.FRAGMENT.value,
@@ -145,7 +136,8 @@ class FragmentManager(
                 timestamp = packet.timestamp,
                 payload = fragmentPayload.encode(),
                 route = packet.route,
-                signature = null // iOS: signature: nil
+                signature = null, // iOS: signature: nil
+                isRSR = packet.isRSR,
             )
             
             fragments.add(fragmentPacket)
@@ -161,8 +153,7 @@ class FragmentManager(
     }
     
     /**
-     * Handle incoming fragment - 100% iOS Compatible  
-     * Matches iOS handleFragment() implementation exactly
+     * Handle an incoming fragment packet; returns the reassembled original when complete.
      */
     fun handleFragment(packet: BitchatPacket): BitchatPacket? {
         // iOS: guard packet.payload.count > 13 else { return }
@@ -267,15 +258,22 @@ class FragmentManager(
                 if (fragmentMap.size == expectedTotal) {
                     Log.d(TAG, "All fragments received for $fragmentIDString, reassembling...")
 
-                    // iOS reassembly logic: for i in 0..<total { if let fragment = fragments[i] { reassembled.append(fragment) } }
-                    val reassembledData = mutableListOf<Byte>()
+                    // Contiguous copy — avoid boxing every byte into List<Byte> (breaks ~1 MiB files).
+                    val totalBytes = fragmentCumulativeSize[fragmentIDString] ?: 0
+                    val reassembledData = ByteArray(totalBytes)
+                    var offset = 0
                     for (i in 0 until expectedTotal) {
-                        fragmentMap[i]?.let { data ->
-                            reassembledData.addAll(data.asIterable())
+                        val chunk = fragmentMap[i]
+                        if (chunk == null) {
+                            Log.e(TAG, "Missing fragment index $i for $fragmentIDString during reassembly")
+                            removeFragmentSetLocked(fragmentIDString)
+                            return null
                         }
+                        chunk.copyInto(reassembledData, destinationOffset = offset)
+                        offset += chunk.size
                     }
 
-                    val originalPacket = BitchatPacket.fromBinaryData(reassembledData.toByteArray())
+                    val originalPacket = BitchatPacket.fromBinaryData(reassembledData)
                     if (originalPacket != null) {
                         removeFragmentSetLocked(fragmentIDString)
 

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshComponentWiring.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshComponentWiring.kt
@@ -441,8 +441,12 @@ internal class MeshComponentWiring(
 
     private fun wirePacketProcessor() {
         packetProcessor.delegate = object : PacketProcessorDelegate {
-            override fun validatePacketSecurity(packet: BitchatPacket, peerID: String): PacketValidationResult {
-                return securityManager.validatePacket(packet, peerID)
+            override fun validatePacketSecurity(
+                packet: BitchatPacket,
+                peerID: String,
+                previousHopPeerID: String?,
+            ): PacketValidationResult {
+                return securityManager.validatePacket(packet, peerID, previousHopPeerID)
             }
 
             override fun handleDuplicateAnnounceLiveness(routed: RoutedPacket) {
@@ -586,7 +590,8 @@ internal class MeshComponentWiring(
                 scope.launch { messageHandler.handleLeave(routed) }
             }
 
-            override fun handleFragment(packet: BitchatPacket): BitchatPacket? {
+            override fun handleFragment(routed: RoutedPacket): BitchatPacket? {
+                val packet = routed.packet
                 // Track broadcast fragments for gossip sync
                 try {
                     val isBroadcast = (packet.recipientID == null || packet.recipientID.contentEquals(SpecialRecipients.BROADCAST))
@@ -594,6 +599,12 @@ internal class MeshComponentWiring(
                         gossipSyncManager.onPublicPacketSeen(packet)
                     }
                 } catch (_: Exception) { }
+                // iOS BLEFragmentHandler: self-authored fragment replay (incl. RSR after
+                // relaunch) is recorded as seen but never assembled — we authored the
+                // original, so reassembly would only burn fragment budgets.
+                if (!BleFragmentIngressPolicy.shouldAssemble(routed.peerID, myPeerID)) {
+                    return null
+                }
                 return fragmentManager.handleFragment(packet)
             }
 

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshComponentWiring.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshComponentWiring.kt
@@ -80,6 +80,12 @@ internal class MeshComponentWiring(
     }
 
     private fun wireEncryptionCallbacks() {
+        // Flush PMs / typed Noise payloads queued before the XX handshake finished (iOS
+        // BLENoiseSessionQueues). Safe if onKeyExchangeCompleted also flushes — take() is empty
+        // the second time. Each generation re-registers, so the latest wins.
+        encryptionService.onSessionEstablished = { peerID ->
+            outbound.flushPendingAfterHandshake(peerID)
+        }
         // Session-established trigger for transitive verification: on a Noise session coming up with a
         // peer (fingerprint resolved), the vouch coordinator may send a batch. Additive — nothing
         // else consumes this callback. Each generation re-registers, so the latest wins.
@@ -118,6 +124,9 @@ internal class MeshComponentWiring(
         // SecurityManager delegate for key exchange notifications
         securityManager.delegate = object : SecurityManagerDelegate {
             override fun onKeyExchangeCompleted(peerID: String, peerPublicKeyData: ByteArray) {
+                // Drain handshake-deferred private traffic immediately (iOS
+                // sendPendingMessagesAfterHandshake / sendPendingNoisePayloadsAfterHandshake).
+                outbound.flushPendingAfterHandshake(peerID)
                 // Send announcement and cached messages after key exchange
                 scope.launch {
                     Log.d(TAG, "Key exchange completed with $peerID; sending follow-ups")

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshComponentWiring.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshComponentWiring.kt
@@ -62,6 +62,7 @@ internal class MeshComponentWiring(
     private val prekeyListener: () -> PrekeyEventListener?,
     private val nostrCarrierHandler: () -> ((ByteArray, String, Boolean) -> Unit)?,
     private val voiceFrameSink: (PublicVoiceFrame) -> Unit,
+    private val privateVoiceFrameSink: (PublicVoiceFrame) -> Unit = {},
     private val nowMillis: () -> Long,
 ) {
 
@@ -399,6 +400,10 @@ internal class MeshComponentWiring(
 
             override fun onVouchAttestationsReceived(peerID: String, payload: ByteArray, timestampMs: Long) {
                 vouchListener()?.onVouchAttestations(peerID, payload, timestampMs)
+            }
+
+            override fun onPrivateVoiceFrameReceived(peerID: String, payload: ByteArray, timestampMs: Long) {
+                privateVoiceFrameSink(PublicVoiceFrame(peerID, payload, timestampMs))
             }
 
             // Courier store-and-forward (0x04)

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshCoordinator.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshCoordinator.kt
@@ -48,9 +48,10 @@ internal fun epochMillis(): Long = Clock.System.now().toEpochMilliseconds()
 
 /**
  * Bluetooth mesh service - REFACTORED to use component-based architecture
- * 100% compatible with iOS version and maintains exact same UUIDs, packet format, and protocol logic
- * 
- * This is now a coordinator that orchestrates the following components:
+ * Mesh coordinator: peer lifecycle, security, relay, and multi-bearer packet flow.
+ * GATT UUIDs and packet wire format aim for iOS bitchat interop (not full product parity).
+ *
+ * Orchestrates the following components:
  * - PeerManager: Peer lifecycle management
  * - FragmentManager: Message fragmentation and reassembly  
  * - SecurityManager: Security, duplicate detection, encryption
@@ -107,9 +108,18 @@ class MeshCoordinator(
     // Engine components. Rebuilt in place by reset()/revival — the BMS object itself keeps
     // its graph identity, so  consumers never hold a stale reference.
     private var peerManager = PeerManager(peerFingerprintManager)
+    // SecurityManager is rebuilt after gossipSyncManager in wireComponents so RSR
+    // solicitation can share the same RequestSyncManager instance.
     private var securityManager = SecurityManager(encryptionService, myPeerID, trafficLog = debugSettingsManager)
     private var storeForwardManager = StoreForwardManager()
-    private var messageHandler = MessageHandler(myPeerID, incomingFileStore, meshGraphService, dispatchers)
+    private val selfBroadcastTracker = BleSelfBroadcastTracker()
+    private var messageHandler = MessageHandler(
+        myPeerID,
+        incomingFileStore,
+        meshGraphService,
+        dispatchers,
+        selfBroadcastTracker,
+    )
 
     /**
      * Narrow BLE debug surface for [com.bitchat.android.ui.debug.DebugSettingsSheet]
@@ -201,6 +211,16 @@ class MeshCoordinator(
             }
         )
 
+        // Shared RSR solicitation gate: BLE ingress + SecurityManager + gossip registry.
+        val isValidRsr: (String) -> Boolean = { peerID -> gossipSyncManager.isValidSyncResponse(peerID) }
+        bleBearer.isValidSyncResponse = isValidRsr
+        securityManager = SecurityManager(
+            encryptionService = encryptionService,
+            myPeerID = myPeerID,
+            trafficLog = debugSettingsManager,
+            isValidSyncResponse = isValidRsr,
+        )
+
         // Outbound send path for the current generation (signing, announces, messaging)
         outbound = MeshOutboundSender(
             myPeerID = myPeerID,
@@ -216,6 +236,7 @@ class MeshCoordinator(
             scope = serviceScope,
             initiateHandshake = { peerID -> messageHandler.delegate?.initiateNoiseHandshake(peerID) },
             gatewayEnabled = { gatewayEnabled },
+            selfBroadcastTracker = selfBroadcastTracker,
         )
 
         // Mesh diagnostics probes. myPeerID is read live (panic reset rotates it) and the probe
@@ -239,6 +260,8 @@ class MeshCoordinator(
             override fun signPacketForBroadcast(packet: BitchatPacket): BitchatPacket {
                 return outbound.signPacketBeforeBroadcast(packet)
             }
+            override fun getConnectedPeers(): List<String> =
+                meshNetwork.allNeighbors.map { it.peerID }.distinct()
         }
 
         // Inter-component delegate wiring for the current generation
@@ -329,6 +352,7 @@ class MeshCoordinator(
         try { storeForwardManager.shutdown() } catch (_: Exception) { }
         try { messageHandler.shutdown() } catch (_: Exception) { }
         try { packetProcessor.shutdown() } catch (_: Exception) { }
+        selfBroadcastTracker.clear()
     }
 
     /**
@@ -341,9 +365,15 @@ class MeshCoordinator(
         myPeerID = encryptionService.getIdentityFingerprint().take(16)
         peerManager = PeerManager(peerFingerprintManager)
         fragmentManager.clearAllFragments()
-        securityManager = SecurityManager(encryptionService, myPeerID, trafficLog = debugSettingsManager)
+        // SecurityManager is rebuilt inside wireComponents with the new gossip RSR gate.
         storeForwardManager = StoreForwardManager()
-        messageHandler = MessageHandler(myPeerID, incomingFileStore, meshGraphService, dispatchers)
+        messageHandler = MessageHandler(
+            myPeerID,
+            incomingFileStore,
+            meshGraphService,
+            dispatchers,
+            selfBroadcastTracker,
+        )
         packetProcessor = PacketProcessor(myPeerID, debugSettingsManager)
         bleBearer.reset(myPeerID)
         wireComponents()
@@ -517,6 +547,9 @@ class MeshCoordinator(
 
     override fun sendMessage(content: String, mentions: List<String>, channel: String?) =
         outbound.sendMessage(content, mentions, channel)
+
+    override fun sendMessage(content: String, mentions: List<String>, channel: String?, messageID: String) =
+        outbound.sendMessage(content, mentions, channel, messageID)
 
     override fun sendFileBroadcast(file: com.app.transport.model.BitchatFilePacket) =
         outbound.sendFileBroadcast(file)

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshCoordinator.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshCoordinator.kt
@@ -156,7 +156,9 @@ class MeshCoordinator(
     override var prekeyEventListener: PrekeyEventListener? = null
     private var nostrCarrierHandler: ((ByteArray, String, Boolean) -> Unit)? = null
     private val voiceFrameEvents = VoiceFrameEventStream()
+    private val privateVoiceFrameEvents = VoiceFrameEventStream()
     override val publicVoiceFrames = voiceFrameEvents.frames
+    override val privateVoiceFrames = privateVoiceFrameEvents.frames
 
     // Coroutines
     private var serviceScope = CoroutineScope(dispatchers.io + SupervisorJob())
@@ -267,6 +269,7 @@ class MeshCoordinator(
             prekeyListener = { prekeyEventListener },
             nostrCarrierHandler = { nostrCarrierHandler },
             voiceFrameSink = voiceFrameEvents::emit,
+            privateVoiceFrameSink = privateVoiceFrameEvents::emit,
             nowMillis = { epochMillis() },
         ).wire()
         messageHandler.packetProcessor = packetProcessor
@@ -574,6 +577,9 @@ class MeshCoordinator(
     override fun broadcastNostrCarrier(payload: ByteArray) = outbound.broadcastNostrCarrier(payload)
 
     override fun broadcastVoiceFrame(payload: ByteArray) = outbound.broadcastVoiceFrame(payload)
+
+    override fun sendVoiceFrame(payload: ByteArray, toPeerID: String) =
+        outbound.sendVoiceFrame(payload, toPeerID)
 
     override fun connectedPeerIDs(): List<String> =
         try { peerManager.getActivePeerIDs() } catch (_: Exception) { emptyList() }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshOutboundSender.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshOutboundSender.kt
@@ -123,65 +123,38 @@ internal class MeshOutboundSender(
     }
 
     /**
-     * Send a file as an encrypted private message using Noise protocol
+     * Send a private file as a directed, signed outer [MessageType.FILE_TRANSFER] (0x22) —
+     * byte-compatible with native iOS `BLEService.sendFilePrivate`. Content confidentiality
+     * is not Noise-wrapped on this path (same as reference); authenticity is the Ed25519 packet
+     * signature. Receivers also still accept legacy Noise-wrapped FILE_TRANSFER 0x20 from older KMP.
      */
     fun sendFilePrivate(recipientPeerID: String, file: BitchatFilePacket) {
         try {
-            Log.d(TAG, "📤 sendFilePrivate (ENCRYPTED): to=$recipientPeerID, name=${file.fileName}, size=${file.fileSize}")
-
+            Log.d(TAG, "📤 sendFilePrivate (0x22 directed): to=$recipientPeerID, name=${file.fileName}, size=${file.fileSize}")
             scope.launch {
-                // Check if we have an established Noise session
-                if (encryptionService.hasEstablishedSession(recipientPeerID)) {
-                    try {
-                        // Encode the file packet as TLV
-                        val filePayload = file.encode()
-                        if (filePayload == null) {
-                            Log.e(TAG, "❌ Failed to encode file packet for private send")
-                            return@launch
-                        }
-                        Log.d(TAG, "📦 Encoded file TLV: ${filePayload.size} bytes")
-
-                        // Create NoisePayload wrapper (type byte + file TLV data) - same as iOS
-                        val noisePayload = NoisePayload(
-                            type = NoisePayloadType.FILE_TRANSFER,
-                            data = filePayload
-                        )
-
-                        // Encrypt the payload using Noise
-                        val encrypted = encryptionService.encrypt(noisePayload.encode(), recipientPeerID)
-                        if (encrypted == null) {
-                            Log.e(TAG, "❌ Failed to encrypt file for $recipientPeerID")
-                            return@launch
-                        }
-                        Log.d(TAG, "🔐 Encrypted file payload: ${encrypted.size} bytes")
-
-                        // Create NOISE_ENCRYPTED packet (not FILE_TRANSFER!)
-                        val packet = BitchatPacket(
-                            version = 1u,
-                            type = MessageType.NOISE_ENCRYPTED.value,
-                            senderID = peerIdToRoutingBytes(myPeerID),
-                            recipientID = peerIdToRoutingBytes(recipientPeerID),
-                            timestamp = epochMillis().toULong(),
-                            payload = encrypted,
-                            signature = null,
-                            ttl = MeshConstants.MESSAGE_TTL_HOPS
-                        )
-
-                        // Sign and send the encrypted packet
-                        val signed = signPacketBeforeBroadcast(packet)
-                        // Use a stable transferId based on the unencrypted file TLV payload for progress tracking
-                        val transferId = sha256Hex(filePayload)
-                        meshNetwork.broadcast(RoutedPacket(signed, transferId = transferId))
-                        Log.d(TAG, "✅ Sent encrypted file to $recipientPeerID")
-
-                    } catch (e: Exception) {
-                        Log.e(TAG, "❌ Failed to encrypt file for $recipientPeerID: ${e.message}", e)
-                    }
-                } else {
-                    // No session - initiate handshake but don't queue file
-                    Log.w(TAG, "⚠️ No Noise session with $recipientPeerID for file transfer, initiating handshake")
-                    initiateHandshake(recipientPeerID)
+                val filePayload = file.encode()
+                if (filePayload == null) {
+                    Log.e(TAG, "❌ Failed to encode file packet for private send")
+                    return@launch
                 }
+                val packet = BitchatPacket(
+                    version = 2u,
+                    type = MessageType.FILE_TRANSFER.value,
+                    senderID = peerIdToRoutingBytes(myPeerID),
+                    recipientID = peerIdToRoutingBytes(recipientPeerID),
+                    timestamp = epochMillis().toULong(),
+                    payload = filePayload,
+                    signature = null,
+                    ttl = MeshConstants.MESSAGE_TTL_HOPS,
+                )
+                val signed = signPacketBeforeBroadcast(packet)
+                if (signed.signature == null) {
+                    Log.e(TAG, "❌ Failed to sign private file transfer to $recipientPeerID")
+                    return@launch
+                }
+                val transferId = sha256Hex(filePayload)
+                meshNetwork.broadcast(RoutedPacket(signed, transferId = transferId))
+                Log.d(TAG, "✅ Sent private file transfer (0x22) to $recipientPeerID (${filePayload.size} bytes)")
             }
         } catch (e: Exception) {
             Log.e(TAG, "❌ sendFilePrivate failed: ${e.message}", e)
@@ -533,6 +506,19 @@ internal class MeshOutboundSender(
             timestamp = epochMillis().toULong(), payload = payload, signature = null, ttl = MAX_TTL,
         )
         meshNetwork.broadcast(RoutedPacket(packet))
+    }
+
+    /**
+     * DM live voice: [NoisePayloadType.VOICE_FRAME] (0x08) inside directed noiseEncrypted —
+     * iOS `sendVoiceFrame` parity. Requires an established Noise session.
+     */
+    fun sendVoiceFrame(payload: ByteArray, toPeerID: String) {
+        if (payload.isEmpty() || toPeerID.isEmpty()) return
+        sendNoisePayloadToPeer(
+            NoisePayload(NoisePayloadType.VOICE_FRAME, payload),
+            toPeerID,
+            "voice frame",
+        )
     }
 
     /** Sends one encoded public live-voice burst without persistence or gossip-sync tracking. */

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshOutboundSender.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshOutboundSender.kt
@@ -51,6 +51,7 @@ internal class MeshOutboundSender(
     private val initiateHandshake: (String) -> Unit,
     private val gatewayEnabled: () -> Boolean = { false },
     private val pendingNoise: BleNoiseSessionQueues = BleNoiseSessionQueues(),
+    private val selfBroadcastTracker: BleSelfBroadcastTracker = BleSelfBroadcastTracker(),
 ) {
 
     companion object {
@@ -64,7 +65,7 @@ internal class MeshOutboundSender(
     /**
      * Send public message
      */
-    fun sendMessage(content: String, mentions: List<String>, channel: String?) {
+    fun sendMessage(content: String, mentions: List<String>, channel: String?, messageID: String? = null) {
         if (content.isEmpty()) return
 
         scope.launch {
@@ -81,6 +82,9 @@ internal class MeshOutboundSender(
 
             // Sign the packet before broadcasting
             val signedPacket = signPacketBeforeBroadcast(packet)
+            if (messageID != null) {
+                selfBroadcastTracker.record(messageID, signedPacket, packet.timestamp.toLong())
+            }
             meshNetwork.broadcast(RoutedPacket(signedPacket))
             // Track our own broadcast message for sync
             try { gossipSyncManager.onPublicPacketSeen(signedPacket) } catch (_: Exception) { }
@@ -164,7 +168,7 @@ internal class MeshOutboundSender(
 
     /**
      * Send private message - SIMPLIFIED iOS-compatible version
-     * Uses NoisePayloadType system exactly like iOS SimplifiedBluetoothService
+     * NoisePayloadType private-message path (directed noiseEncrypted).
      */
     fun sendPrivateMessage(content: String, recipientPeerID: String, recipientNickname: String, messageID: String?) {
         if (content.isEmpty() || recipientPeerID.isEmpty()) return
@@ -263,6 +267,7 @@ internal class MeshOutboundSender(
         val payloads = pendingNoise.takeTypedPayloads(peerID)
         if (payloads.isEmpty()) return
         Log.d(TAG, "📤 Sending ${payloads.size} pending Noise payloads after handshake to ${peerID.take(8)}…")
+        val failed = mutableListOf<ByteArray>()
         for (typedPayload in payloads) {
             try {
                 val encrypted = encryptionService.encrypt(typedPayload, peerID)
@@ -279,7 +284,12 @@ internal class MeshOutboundSender(
                 meshNetwork.broadcast(RoutedPacket(signPacketBeforeBroadcast(packet)))
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send pending Noise payload to ${peerID.take(8)}…: ${e.message}")
+                failed.add(typedPayload)
             }
+        }
+        if (failed.isNotEmpty()) {
+            pendingNoise.prependTypedPayloads(failed, peerID)
+            Log.w(TAG, "⚠️ Re-queued ${failed.size} failed pending Noise payloads for ${peerID.take(8)}…")
         }
     }
 
@@ -510,15 +520,36 @@ internal class MeshOutboundSender(
 
     /**
      * DM live voice: [NoisePayloadType.VOICE_FRAME] (0x08) inside directed noiseEncrypted —
-     * iOS `sendVoiceFrame` parity. Requires an established Noise session.
+     * iOS `sendVoiceFrame` parity. Fire-and-forget: without an established Noise session the
+     * frame is dropped immediately (stale live audio must never queue behind a handshake).
      */
     fun sendVoiceFrame(payload: ByteArray, toPeerID: String) {
         if (payload.isEmpty() || toPeerID.isEmpty()) return
-        sendNoisePayloadToPeer(
-            NoisePayload(NoisePayloadType.VOICE_FRAME, payload),
-            toPeerID,
-            "voice frame",
-        )
+        scope.launch {
+            if (!encryptionService.hasEstablishedSession(toPeerID)) {
+                Log.d(TAG, "PTT: dropping voice frame — no established session with ${toPeerID.take(8)}…")
+                return@launch
+            }
+            try {
+                val typed = NoisePayload(NoisePayloadType.VOICE_FRAME, payload).encode()
+                val encrypted = encryptionService.encrypt(typed, toPeerID)
+                val packet = BitchatPacket(
+                    version = 1u,
+                    type = MessageType.NOISE_ENCRYPTED.value,
+                    senderID = peerIdToRoutingBytes(myPeerID),
+                    recipientID = peerIdToRoutingBytes(toPeerID),
+                    timestamp = epochMillis().toULong(),
+                    payload = encrypted,
+                    signature = null,
+                    ttl = MeshConstants.MESSAGE_TTL_HOPS,
+                )
+                val signedPacket = signPacketBeforeBroadcast(packet)
+                meshNetwork.broadcast(RoutedPacket(signedPacket))
+                Log.d(TAG, "📤 Sent voice frame to $toPeerID (${payload.size} bytes)")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send voice frame to $toPeerID: ${e.message}")
+            }
+        }
     }
 
     /** Sends one encoded public live-voice burst without persistence or gossip-sync tracking. */
@@ -576,7 +607,7 @@ internal class MeshOutboundSender(
     }
 
     /**
-     * Send broadcast announce with TLV-encoded identity announcement - exactly like iOS
+     * Send broadcast announce with TLV-encoded identity announcement
      */
     fun sendBroadcastAnnounce() {
         Log.d(TAG, "Sending broadcast announce")
@@ -603,7 +634,7 @@ internal class MeshOutboundSender(
     }
 
     /**
-     * Send announcement to specific peer with TLV-encoded identity announcement - exactly like iOS
+     * Send announcement to specific peer with TLV-encoded identity announcement
      */
     fun sendAnnouncementToPeer(peerID: String) {
         if (peerManager.hasAnnouncedToPeer(peerID)) return

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshOutboundSender.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshOutboundSender.kt
@@ -50,12 +50,16 @@ internal class MeshOutboundSender(
     private val scope: CoroutineScope,
     private val initiateHandshake: (String) -> Unit,
     private val gatewayEnabled: () -> Boolean = { false },
+    private val pendingNoise: BleNoiseSessionQueues = BleNoiseSessionQueues(),
 ) {
 
     companion object {
         private const val TAG = "MeshOutboundSender"
         private val MAX_TTL: UByte = MeshConstants.MESSAGE_TTL_HOPS
     }
+
+    /** Drop any pending handshake-deferred traffic (panic / generation rebuild). */
+    fun clearPendingNoiseQueues() = pendingNoise.clear()
 
     /**
      * Send public message
@@ -200,52 +204,108 @@ internal class MeshOutboundSender(
 
             // Check if we have an established Noise session
             if (encryptionService.hasEstablishedSession(recipientPeerID)) {
-                try {
-                    // Create TLV-encoded private message exactly like iOS
-                    val privateMessage = PrivateMessagePacket(
-                        messageID = finalMessageID,
-                        content = content
-                    )
-
-                    val tlvData = privateMessage.encode()
-                    if (tlvData == null) {
-                        Log.e(TAG, "Failed to encode private message with TLV")
-                        return@launch
-                    }
-
-                    // Create message payload with NoisePayloadType prefix: [type byte] + [TLV data]
-                    val messagePayload = NoisePayload(
-                        type = NoisePayloadType.PRIVATE_MESSAGE,
-                        data = tlvData
-                    )
-
-                    // Encrypt the payload
-                    val encrypted = encryptionService.encrypt(messagePayload.encode(), recipientPeerID)
-
-                    // Create NOISE_ENCRYPTED packet exactly like iOS
-                    val packet = BitchatPacket(
-                        version = 1u,
-                        type = MessageType.NOISE_ENCRYPTED.value,
-                        senderID = peerIdToRoutingBytes(myPeerID),
-                        recipientID = peerIdToRoutingBytes(recipientPeerID),
-                        timestamp = epochMillis().toULong(),
-                        payload = encrypted,
-                        signature = null,
-                        ttl = MAX_TTL
-                    )
-
-                    // Sign the packet before broadcasting
-                    val signedPacket = signPacketBeforeBroadcast(packet)
-                    meshNetwork.broadcast(RoutedPacket(signedPacket))
-                    Log.d(TAG, "📤 Sent encrypted private message to $recipientPeerID (${encrypted.size} bytes)")
-
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to encrypt private message for $recipientPeerID: ${e.message}")
+                if (!sendEncryptedPrivateMessage(content, finalMessageID, recipientPeerID)) {
+                    // Session may have raced out from under us — queue + re-handshake like iOS.
+                    pendingNoise.appendPrivateMessage(content, finalMessageID, recipientPeerID)
+                    initiateHandshake(recipientPeerID)
                 }
             } else {
-                // Fire and forget - initiate handshake but don't queue exactly like iOS
-                Log.d(TAG, "🤝 No session with $recipientPeerID, initiating handshake")
+                // iOS BLENoiseSessionQueues: hold the PM until XX completes, then flush.
+                Log.d(TAG, "🤝 No session with $recipientPeerID, queueing PM and initiating handshake")
+                pendingNoise.appendPrivateMessage(content, finalMessageID, recipientPeerID)
                 initiateHandshake(recipientPeerID)
+            }
+        }
+    }
+
+    /**
+     * Flush private messages and typed Noise payloads deferred until handshake completion.
+     * Safe to call multiple times (empty take is a no-op). Invoked from session-established wiring.
+     */
+    fun flushPendingAfterHandshake(peerID: String) {
+        if (peerID.isEmpty()) return
+        scope.launch {
+            sendPendingPrivateMessagesAfterHandshake(peerID)
+            sendPendingTypedPayloadsAfterHandshake(peerID)
+        }
+    }
+
+    private fun sendEncryptedPrivateMessage(
+        content: String,
+        messageID: String,
+        recipientPeerID: String,
+    ): Boolean {
+        return try {
+            val privateMessage = PrivateMessagePacket(
+                messageID = messageID,
+                content = content
+            )
+            val tlvData = privateMessage.encode()
+            if (tlvData == null) {
+                Log.e(TAG, "Failed to encode private message with TLV")
+                return false
+            }
+            val messagePayload = NoisePayload(
+                type = NoisePayloadType.PRIVATE_MESSAGE,
+                data = tlvData
+            )
+            val encrypted = encryptionService.encrypt(messagePayload.encode(), recipientPeerID)
+            val packet = BitchatPacket(
+                version = 1u,
+                type = MessageType.NOISE_ENCRYPTED.value,
+                senderID = peerIdToRoutingBytes(myPeerID),
+                recipientID = peerIdToRoutingBytes(recipientPeerID),
+                timestamp = epochMillis().toULong(),
+                payload = encrypted,
+                signature = null,
+                ttl = MAX_TTL
+            )
+            val signedPacket = signPacketBeforeBroadcast(packet)
+            meshNetwork.broadcast(RoutedPacket(signedPacket))
+            Log.d(TAG, "📤 Sent encrypted private message to $recipientPeerID (${encrypted.size} bytes)")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to encrypt private message for $recipientPeerID: ${e.message}")
+            false
+        }
+    }
+
+    private fun sendPendingPrivateMessagesAfterHandshake(peerID: String) {
+        val pending = pendingNoise.takePrivateMessages(peerID)
+        if (pending.isEmpty()) return
+        Log.d(TAG, "📤 Sending ${pending.size} pending PMs after handshake to ${peerID.take(8)}…")
+        val failed = mutableListOf<BleNoiseSessionQueues.PendingPrivateMessage>()
+        for (message in pending) {
+            if (!sendEncryptedPrivateMessage(message.content, message.messageID, peerID)) {
+                failed.add(message)
+            }
+        }
+        if (failed.isNotEmpty()) {
+            pendingNoise.prependPrivateMessages(failed, peerID)
+            Log.w(TAG, "⚠️ Re-queued ${failed.size} failed pending PMs for ${peerID.take(8)}…")
+        }
+    }
+
+    private fun sendPendingTypedPayloadsAfterHandshake(peerID: String) {
+        val payloads = pendingNoise.takeTypedPayloads(peerID)
+        if (payloads.isEmpty()) return
+        Log.d(TAG, "📤 Sending ${payloads.size} pending Noise payloads after handshake to ${peerID.take(8)}…")
+        for (typedPayload in payloads) {
+            try {
+                val encrypted = encryptionService.encrypt(typedPayload, peerID)
+                val packet = BitchatPacket(
+                    version = 1u,
+                    type = MessageType.NOISE_ENCRYPTED.value,
+                    senderID = peerIdToRoutingBytes(myPeerID),
+                    recipientID = peerIdToRoutingBytes(peerID),
+                    timestamp = epochMillis().toULong(),
+                    payload = encrypted,
+                    signature = null,
+                    ttl = MeshConstants.MESSAGE_TTL_HOPS
+                )
+                meshNetwork.broadcast(RoutedPacket(signPacketBeforeBroadcast(packet)))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send pending Noise payload to ${peerID.take(8)}…: ${e.message}")
             }
         }
     }
@@ -270,16 +330,18 @@ internal class MeshOutboundSender(
                     return@launch
                 }
 
-                // Create read receipt payload using NoisePayloadType exactly like iOS
                 val readReceiptPayload = NoisePayload(
                     type = NoisePayloadType.READ_RECEIPT,
                     data = messageID.encodeToByteArray()
                 )
+                if (!encryptionService.hasEstablishedSession(recipientPeerID)) {
+                    pendingNoise.appendTypedPayload(readReceiptPayload.encode(), recipientPeerID)
+                    initiateHandshake(recipientPeerID)
+                    Log.d(TAG, "🕒 Queued read receipt for $recipientPeerID until handshake completes")
+                    return@launch
+                }
 
-                // Encrypt the payload
                 val encrypted = encryptionService.encrypt(readReceiptPayload.encode(), recipientPeerID)
-
-                // Create NOISE_ENCRYPTED packet exactly like iOS
                 val packet = BitchatPacket(
                     version = 1u,
                     type = MessageType.NOISE_ENCRYPTED.value,
@@ -288,17 +350,12 @@ internal class MeshOutboundSender(
                     timestamp = epochMillis().toULong(),
                     payload = encrypted,
                     signature = null,
-                    ttl = MeshConstants.MESSAGE_TTL_HOPS // Same TTL as iOS messageTTL
+                    ttl = MeshConstants.MESSAGE_TTL_HOPS
                 )
-
-                // Sign the packet before broadcasting
                 val signedPacket = signPacketBeforeBroadcast(packet)
                 meshNetwork.broadcast(RoutedPacket(signedPacket))
                 Log.d(TAG, "📤 Sent read receipt to $recipientPeerID for message $messageID")
-
-                // Persist as read after successful send
                 seenMessageStore.markRead(messageID)
-
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send read receipt to $recipientPeerID: ${e.message}")
             }
@@ -503,8 +560,15 @@ internal class MeshOutboundSender(
 
     private fun sendNoisePayloadToPeer(payload: NoisePayload, recipientPeerID: String, label: String) {
         scope.launch {
+            val typed = payload.encode()
+            if (!encryptionService.hasEstablishedSession(recipientPeerID)) {
+                pendingNoise.appendTypedPayload(typed, recipientPeerID)
+                initiateHandshake(recipientPeerID)
+                Log.d(TAG, "🕒 Queued $label for $recipientPeerID until handshake completes")
+                return@launch
+            }
             try {
-                val encrypted = encryptionService.encrypt(payload.encode(), recipientPeerID)
+                val encrypted = encryptionService.encrypt(typed, recipientPeerID)
                 val packet = BitchatPacket(
                     version = 1u,
                     type = MessageType.NOISE_ENCRYPTED.value,

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshService.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshService.kt
@@ -161,4 +161,14 @@ interface MeshService {
 
     /** Broadcasts one already-encoded live voice burst as signed, ephemeral 0x29 traffic. */
     fun broadcastVoiceFrame(payload: ByteArray) = Unit
+
+    /**
+     * DM live voice: Noise payload type 0x08 inside directed noiseEncrypted.
+     * Requires an established Noise session (queues until handshake like other typed payloads).
+     */
+    fun sendVoiceFrame(payload: ByteArray, toPeerID: String) = Unit
+
+    /** Inbound private live-voice frames (Noise 0x08), same payload framing as public bursts. */
+    val privateVoiceFrames: Flow<PublicVoiceFrame>
+        get() = emptyFlow()
 }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshService.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MeshService.kt
@@ -44,6 +44,9 @@ interface MeshService {
 
     fun sendMessage(content: String, mentions: List<String> = emptyList(), channel: String? = null)
 
+    fun sendMessage(content: String, mentions: List<String>, channel: String?, messageID: String) =
+        sendMessage(content, mentions, channel)
+
     fun sendPrivateMessage(
         content: String,
         recipientPeerID: String,
@@ -164,7 +167,7 @@ interface MeshService {
 
     /**
      * DM live voice: Noise payload type 0x08 inside directed noiseEncrypted.
-     * Requires an established Noise session (queues until handshake like other typed payloads).
+     * Fire-and-forget: drops when no established Noise session (iOS sendVoiceFrame parity).
      */
     fun sendVoiceFrame(payload: ByteArray, toPeerID: String) = Unit
 

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MessageHandler.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MessageHandler.kt
@@ -43,6 +43,7 @@ internal class MessageHandler(
     private val incomingFileStore: IncomingFileStore,
     private val meshGraphService: MeshGraphService,
     dispatchers: AppDispatchers = AppDispatchers(),
+    private val selfBroadcastTracker: BleSelfBroadcastTracker = BleSelfBroadcastTracker(),
 ) {
     
     companion object {
@@ -70,7 +71,7 @@ internal class MessageHandler(
 
     /**
      * Handle Noise encrypted transport message - SIMPLIFIED iOS-compatible version
-     * Uses NoisePayloadType system exactly like iOS SimplifiedBluetoothService
+     * NoisePayloadType dispatch for directed noiseEncrypted payloads.
      */
     fun handleNoiseEncrypted(routed: RoutedPacket) {
         val packet = routed.packet
@@ -494,7 +495,12 @@ internal class MessageHandler(
     fun handleMessage(routed: RoutedPacket) {
         val packet = routed.packet
         val peerID = routed.peerID ?: "unknown"
-        if (peerID == myPeerID) return
+        // Ordinary self-echo is dropped; solicited self-authored RSR (ttl=0) is kept
+        // so public history can re-enter after relaunch (iOS BLEPublicMessagePolicy).
+        val isSelfAuthoredRsr = BleIngressLinkRegistry.isSelfAuthoredSyncResponse(
+            packet, peerID, myPeerID,
+        )
+        if (peerID == myPeerID && !isSelfAuthoredRsr) return
         val senderNickname = delegate?.getPeerNickname(peerID)
         if (senderNickname != null) {
             Log.d(TAG, "Received message from $senderNickname")
@@ -519,12 +525,29 @@ internal class MessageHandler(
     private fun handleBroadcastMessage(routed: RoutedPacket) {
         val packet = routed.packet
         val peerID = routed.peerID ?: "unknown"
+        val isSelf = peerID == myPeerID
         
-        // Enforce: only accept public messages from verified peers we know
-        val peerInfo = delegate?.getPeerInfo(peerID)
-        if (peerInfo == null || !peerInfo.isVerifiedNickname) {
-            Log.w(TAG, "🚫 Dropping public message from unverified or unknown peer ${peerID.take(8)}...")
-            return
+        // Enforce: only accept public messages from verified peers we know.
+        // Self-authored solicited RSR is exempt (iOS: isSelf skips registry gate).
+        if (!isSelf) {
+            val peerInfo = delegate?.getPeerInfo(peerID)
+            if (peerInfo == null || !peerInfo.isVerifiedNickname) {
+                Log.w(TAG, "🚫 Dropping public message from unverified or unknown peer ${peerID.take(8)}...")
+                return
+            }
+        }
+
+        // Display name: local nickname for self-RSR, registry nickname for peers.
+        val senderDisplayName = if (isSelf) {
+            delegate?.getMyNickname()?.takeIf { it.isNotBlank() } ?: peerID.take(8)
+        } else {
+            delegate?.getPeerNickname(peerID) ?: "unknown"
+        }
+        val messageId = if (isSelf) {
+            selfBroadcastTracker.takeMessageID(packet)
+                ?: PacketIdUtil.computeIdHex(packet).uppercase()
+        } else {
+            PacketIdUtil.computeIdHex(packet).uppercase()
         }
         
         try {
@@ -537,10 +560,8 @@ internal class MessageHandler(
                 }
                 val savedPath = incomingFileStore.saveIncomingFile(file)
                 val message = BitchatMessage(
-                    // Stable content-derived id: request-sync replays of the same packet
-                    // must collapse to one message (upstream #707)
-                    id = PacketIdUtil.computeIdHex(packet).uppercase(),
-                    sender = delegate?.getPeerNickname(peerID) ?: "unknown",
+                    id = messageId,
+                    sender = senderDisplayName,
                     content = savedPath,
                     type = messageTypeForMime(file.mimeType),
                     senderPeerID = peerID,
@@ -555,8 +576,8 @@ internal class MessageHandler(
 
             // Fallback: plain text
             val message = BitchatMessage(
-                id = PacketIdUtil.computeIdHex(packet).uppercase(),
-                sender = delegate?.getPeerNickname(peerID) ?: "unknown",
+                id = messageId,
+                sender = senderDisplayName,
                 content = packet.payload.decodeToString(),
                 senderPeerID = peerID,
                 timestamp = Instant.fromEpochMilliseconds(packet.timestamp.toLong())

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MessageHandler.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/MessageHandler.kt
@@ -149,7 +149,7 @@ internal class MessageHandler(
                 }
                 
                 NoisePayloadType.FILE_TRANSFER -> {
-                    // Handle encrypted file transfer; generate unique message ID
+                    // Legacy KMP Noise-wrapped private file (0x20). Prefer outer 0x22 from native iOS.
                     val file = BitchatFilePacket.decode(noisePayload.data)
                     if (file != null) {
                         Log.d(TAG, "🔓 Decrypted encrypted file from $peerID: name='${file.fileName}', size=${file.fileSize}, mime='${file.mimeType}'")
@@ -175,6 +175,16 @@ internal class MessageHandler(
                     } else {
                         Log.w(TAG, "⚠️ Failed to decode encrypted file transfer from $peerID")
                     }
+                }
+
+                NoisePayloadType.VOICE_FRAME -> {
+                    // DM live voice (iOS NoisePayloadType.voiceFrame 0x08)
+                    Log.d(TAG, "🎙️ Private voice frame from $peerID (${noisePayload.data.size} bytes)")
+                    delegate?.onPrivateVoiceFrameReceived(
+                        peerID,
+                        noisePayload.data,
+                        packet.timestamp.toLong(),
+                    )
                 }
                 
                 NoisePayloadType.DELIVERED -> {
@@ -746,6 +756,8 @@ internal interface MessageHandlerDelegate {
     fun onVerifyChallengeReceived(peerID: String, payload: ByteArray, timestampMs: Long)
     fun onVerifyResponseReceived(peerID: String, payload: ByteArray, timestampMs: Long)
     fun onVouchAttestationsReceived(peerID: String, payload: ByteArray, timestampMs: Long)
+    /** DM live voice burst payload (Noise 0x08). Default no-op for tests/stubs. */
+    fun onPrivateVoiceFrameReceived(peerID: String, payload: ByteArray, timestampMs: Long) {}
 
     // Courier store-and-forward (0x04)
     /** Our own Noise static public key, for computing our courier recipient tags. */

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/PacketProcessor.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/PacketProcessor.kt
@@ -162,7 +162,7 @@ internal class PacketProcessor(
     }
     
     /**
-     * Handle received packet - core protocol logic (exact same as iOS)
+     * Handle a received packet (security validation, type dispatch, relay).
      */
     private suspend fun handleReceivedPacket(routed: RoutedPacket) {
         val packet = routed.packet
@@ -171,7 +171,7 @@ internal class PacketProcessor(
         // Basic validation and security checks. A null delegate (teardown/rebuild window)
         // drops the packet — never NPE inside the per-peer consumer coroutine, which would
         // permanently kill that peer's actor.
-        when (delegate?.validatePacketSecurity(packet, peerID)) {
+        when (delegate?.validatePacketSecurity(packet, peerID, routed.previousHopPeerID)) {
             PacketValidationResult.ACCEPT -> Unit
             PacketValidationResult.DUPLICATE -> {
                 // Another neighbor has already supplied this packet. If our degree is high
@@ -355,10 +355,18 @@ internal class PacketProcessor(
         val peerID = routed.peerID ?: "unknown"
         Log.d(TAG, "Processing fragment from ${formatPeerForLog(peerID)}")
         
-        val reassembledPacket = delegate?.handleFragment(routed.packet)
+        val reassembledPacket = delegate?.handleFragment(routed)
         if (reassembledPacket != null) {
             Log.d(TAG, "Fragment reassembled, processing complete message")
-            handleReceivedPacket(RoutedPacket(reassembledPacket, routed.peerID, routed.relayAddress))
+            // Preserve hop metadata so RSR solicitation still keys on the radio hop.
+            handleReceivedPacket(
+                RoutedPacket(
+                    packet = reassembledPacket,
+                    peerID = routed.peerID,
+                    relayAddress = routed.relayAddress,
+                    previousHopPeerID = routed.previousHopPeerID,
+                ),
+            )
         }
         
         // Fragment relay is now handled by centralized PacketRelayManager
@@ -427,8 +435,12 @@ internal class PacketProcessor(
  * Delegate interface for packet processor callbacks
  */
 internal interface PacketProcessorDelegate {
-    // Security validation
-    fun validatePacketSecurity(packet: BitchatPacket, peerID: String): PacketValidationResult
+    // Security validation — [peerID] is logical author; [previousHopPeerID] is radio hop (RSR solicit).
+    fun validatePacketSecurity(
+        packet: BitchatPacket,
+        peerID: String,
+        previousHopPeerID: String? = null,
+    ): PacketValidationResult
 
     // Liveness-only path for duplicate direct-neighbor announces: refresh the
     // link→peer binding and last-seen without reprocessing, relaying or sync scheduling.
@@ -453,7 +465,11 @@ internal interface PacketProcessorDelegate {
     fun handleAnnounce(routed: RoutedPacket)
     fun handleMessage(routed: RoutedPacket)
     fun handleLeave(routed: RoutedPacket)
-    fun handleFragment(packet: BitchatPacket): BitchatPacket?
+    /**
+     * Append fragment / reassemble. [routed.peerID] is the logical author of the fragment
+     * packet (claimed sender). Return null when still incomplete, self-authored, or invalid.
+     */
+    fun handleFragment(routed: RoutedPacket): BitchatPacket?
     fun handleRequestSync(routed: RoutedPacket)
 
     /** Directed echo request addressed to us. [linkKey] identifies the ingress link, not the sender. */

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/SecurityManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/SecurityManager.kt
@@ -117,12 +117,17 @@ internal class SecurityManager(
         val currentTime = nowMillis()
         val messageType = MessageType.fromValue(packet.type)
 
+        // RSR packets skip clock skew (iOS BLEIngressPacketGuard); non-RSR use 120s window.
+        // Solicitation authenticity for RSR is best-effort without a full RequestSyncManager
+        // peer budget here — we accept signed RSR frames (signature check still applies when
+        // required by type). InvalidRSR only fires when isRSR && isValidSyncResponse returns false.
         BleIngressPacketGuard.validatePayload(
             packet = packet,
             peerID = peerID,
             nowMs = currentTime,
             maxTimestampSkewMs = BleIngressPacketGuard.DEFAULT_MAX_TIMESTAMP_SKEW_MS,
-            isRSR = false,
+            isRSR = packet.isRSR,
+            isValidSyncResponse = { packet.isRSR },
         )?.let { rejection ->
             when (rejection) {
                 is BleIngressPacketGuard.Rejection.TimestampSkew -> {

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/SecurityManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/SecurityManager.kt
@@ -48,7 +48,7 @@ internal class SecurityManager(
     private val myPeerID: String,
     private val trafficLog: MeshTrafficLog? = null,
     dispatchers: AppDispatchers = AppDispatchers(),
-    nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     
     companion object {
@@ -112,9 +112,34 @@ internal class SecurityManager(
             return PacketValidationResult.DROP
         }
 
-        // Replay attack protection (same 5-minute window as iOS)
-        val currentTime = Clock.System.now().toEpochMilliseconds()
+        // Replay attack protection — first-line clock skew matches iOS BLEIngressPacketGuard (120s).
+        // Use [nowMillis] (injectable) so unit tests can freeze time.
+        val currentTime = nowMillis()
         val messageType = MessageType.fromValue(packet.type)
+
+        BleIngressPacketGuard.validatePayload(
+            packet = packet,
+            peerID = peerID,
+            nowMs = currentTime,
+            maxTimestampSkewMs = BleIngressPacketGuard.DEFAULT_MAX_TIMESTAMP_SKEW_MS,
+            isRSR = false,
+        )?.let { rejection ->
+            when (rejection) {
+                is BleIngressPacketGuard.Rejection.TimestampSkew -> {
+                    Log.w(
+                        TAG,
+                        "Packet timestamp skewed by ${rejection.skewMs}ms " +
+                            "(max ${rejection.maxSkewMs}ms) from ${peerID.take(8)}…",
+                    )
+                    return PacketValidationResult.DROP
+                }
+                is BleIngressPacketGuard.Rejection.InvalidRSR -> {
+                    Log.w(TAG, "Invalid or unsolicited RSR from ${peerID.take(8)}…")
+                    return PacketValidationResult.DROP
+                }
+                else -> Unit
+            }
+        }
 
         // Duplicate detection
         val messageID = generateMessageID(packet)
@@ -311,10 +336,8 @@ internal class SecurityManager(
      * and back-to-back packets sharing sender/timestamp/type are never collapsed.
      * Local-only key — never serialized to the wire.
      */
-    private fun generateMessageID(packet: BitchatPacket): String {
-        val digestPrefix = Sha256.digest(packet.payload).copyOf(4).hexEncodedString()
-        return "${packet.senderID.hexEncodedString()}-${packet.timestamp}-${packet.type}-$digestPrefix"
-    }
+    private fun generateMessageID(packet: BitchatPacket): String =
+        BleIngressLinkRegistry.messageId(packet)
     
     /**
      * Verify packet signature using peer's signing public key

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/SecurityManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/mesh/SecurityManager.kt
@@ -49,6 +49,7 @@ internal class SecurityManager(
     private val trafficLog: MeshTrafficLog? = null,
     dispatchers: AppDispatchers = AppDispatchers(),
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    private val isValidSyncResponse: (peerID: String) -> Boolean = { false },
 ) {
     
     companion object {
@@ -103,11 +104,26 @@ internal class SecurityManager(
     }
     
     /**
-     * Validate packet security (timestamp, replay attacks, duplicates, signatures)
+     * Validate packet security (timestamp, replay attacks, duplicates, signatures).
+     *
+     * @param peerID Logical author ([RoutedPacket.peerID] / packet.senderID) — used for
+     *   signature verification and non-RSR clock-skew attribution.
+     * @param previousHopPeerID Previous radio hop when known. For RSR, solicitation is
+     *   checked against this hop (the peer we asked for sync), not the author of a
+     *   multi-hop replayed packet.
      */
-    fun validatePacket(packet: BitchatPacket, peerID: String): PacketValidationResult {
-        // Skip validation for our own packets
-        if (peerID == myPeerID) {
+    fun validatePacket(
+        packet: BitchatPacket,
+        peerID: String,
+        previousHopPeerID: String? = null,
+    ): PacketValidationResult {
+        // Ordinary self-loopback is dropped. Exception: solicited self-authored RSR
+        // (isRSR && ttl==0) after relaunch — a neighbor returns our public history
+        // (iOS isSelfAuthoredSyncResponse / BLEPublicMessagePolicy ttl==0 self).
+        val isSelfAuthoredRsr = BleIngressLinkRegistry.isSelfAuthoredSyncResponse(
+            packet, peerID, myPeerID,
+        )
+        if (peerID == myPeerID && !isSelfAuthoredRsr) {
             Log.d(TAG, "Skipping validation for our own packet")
             return PacketValidationResult.DROP
         }
@@ -117,39 +133,44 @@ internal class SecurityManager(
         val currentTime = nowMillis()
         val messageType = MessageType.fromValue(packet.type)
 
-        // RSR packets skip clock skew (iOS BLEIngressPacketGuard); non-RSR use 120s window.
-        // Solicitation authenticity for RSR is best-effort without a full RequestSyncManager
-        // peer budget here — we accept signed RSR frames (signature check still applies when
-        // required by type). InvalidRSR only fires when isRSR && isValidSyncResponse returns false.
+        // RSR: skip clock skew; solicitation uses the hop we requested sync from
+        // (previousHopPeerID), not the logical author of the stored packet.
+        // Non-RSR: 120s window attributed to the author peerID.
+        val payloadPeerID = if (packet.isRSR) {
+            previousHopPeerID ?: peerID
+        } else {
+            peerID
+        }
         BleIngressPacketGuard.validatePayload(
             packet = packet,
-            peerID = peerID,
+            peerID = payloadPeerID,
             nowMs = currentTime,
             maxTimestampSkewMs = BleIngressPacketGuard.DEFAULT_MAX_TIMESTAMP_SKEW_MS,
             isRSR = packet.isRSR,
-            isValidSyncResponse = { packet.isRSR },
+            isValidSyncResponse = isValidSyncResponse,
         )?.let { rejection ->
             when (rejection) {
                 is BleIngressPacketGuard.Rejection.TimestampSkew -> {
                     Log.w(
                         TAG,
                         "Packet timestamp skewed by ${rejection.skewMs}ms " +
-                            "(max ${rejection.maxSkewMs}ms) from ${peerID.take(8)}…",
+                            "(max ${rejection.maxSkewMs}ms) from ${payloadPeerID.take(8)}…",
                     )
                     return PacketValidationResult.DROP
                 }
                 is BleIngressPacketGuard.Rejection.InvalidRSR -> {
-                    Log.w(TAG, "Invalid or unsolicited RSR from ${peerID.take(8)}…")
+                    Log.w(TAG, "Invalid or unsolicited RSR from ${payloadPeerID.take(8)}…")
                     return PacketValidationResult.DROP
                 }
                 else -> Unit
             }
         }
 
-        // Duplicate detection
+        // Duplicate detection. Native BLEReceivePipeline skips dedup for ttl==0 self
+        // sync replay so history can re-enter after relaunch.
         val messageID = generateMessageID(packet)
 
-        if (isProcessed(messageID)) {
+        if (isProcessed(messageID) && !isSelfAuthoredRsr) {
             // ANNOUNCE exception: a byte-identical announce re-received at max TTL still
             // proves the direct link is alive (e.g. after a reconnect on a new link), so
             // report it as liveness-only. It must never be reprocessed or relayed again —
@@ -174,10 +195,12 @@ internal class SecurityManager(
         }
 
         // Add to processed messages (cap enforced at insertion — see [recordProcessedMessage])
-        recordProcessedMessage(messageID)
-        messageTimestamps[messageID] = currentTime
+        if (!isSelfAuthoredRsr) {
+            recordProcessedMessage(messageID)
+            messageTimestamps[messageID] = currentTime
+        }
 
-        // Enforce mandatory signature verification
+        // Enforce mandatory signature verification (own Ed25519 key for self-authored RSR).
         if (!verifyPacketSignature(packet, peerID)) {
             Log.w(TAG, "Dropping packet from $peerID due to signature verification failure")
             return PacketValidationResult.DROP
@@ -375,6 +398,10 @@ internal class SecurityManager(
                 } catch (e: Exception) {
                     Log.w(TAG, "Failed to decode announcement for key extraction: ${e.message}")
                 }
+            } else if (peerID == myPeerID) {
+                // Self-authored solicited RSR: verify with our own signing key
+                // (we are not in the peer registry as a remote peer).
+                signingPublicKey = encryptionService.getSigningPublicKey()
             } else {
                 // Standard Case: Get key from known peer info
                 val peerInfo = delegate?.getPeerInfo(peerID)

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/sync/GossipSyncManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/sync/GossipSyncManager.kt
@@ -299,7 +299,8 @@ internal class GossipSyncManager(
                 val idBytes = hexToBytes(id)
                 if (!mightContain(idBytes)) {
                     // Send original packet unchanged to requester only (keep local TTL)
-                    val toSend = pkt.copy(ttl = SyncDefaults.SYNC_TTL_HOPS)
+                    // Mark as solicited response (iOS GossipSyncManager isRSR = true).
+                    val toSend = pkt.copy(ttl = SyncDefaults.SYNC_TTL_HOPS, isRSR = true)
                     delegate?.sendPacketToPeer(fromPeerID, toSend)
                     Log.d(TAG, "Sent sync announce: Type ${toSend.type} from ${toSend.senderID.hexEncodedString()} to $fromPeerID packet id ${idBytes.hexEncodedString()}")
                 }
@@ -313,7 +314,7 @@ internal class GossipSyncManager(
                 if (since != null && pkt.timestamp.toLong() < since) continue
                 val idBytes = PacketIdUtil.computeIdBytes(pkt)
                 if (!mightContain(idBytes)) {
-                    val toSend = pkt.copy(ttl = SyncDefaults.SYNC_TTL_HOPS)
+                    val toSend = pkt.copy(ttl = SyncDefaults.SYNC_TTL_HOPS, isRSR = true)
                     delegate?.sendPacketToPeer(fromPeerID, toSend)
                     Log.d(TAG, "Sent sync message: Type ${toSend.type} to $fromPeerID packet id ${idBytes.hexEncodedString()}")
                 }
@@ -329,7 +330,10 @@ internal class GossipSyncManager(
                     if (since != null && pkt.timestamp.toLong() < since) return@forEach
                     val idBytes = PacketIdUtil.computeIdBytes(pkt)
                     if (!mightContain(idBytes)) {
-                        delegate?.sendPacketToPeer(fromPeerID, pkt.copy(ttl = SyncDefaults.SYNC_TTL_HOPS))
+                        delegate?.sendPacketToPeer(
+                            fromPeerID,
+                            pkt.copy(ttl = SyncDefaults.SYNC_TTL_HOPS, isRSR = true),
+                        )
                     }
                 }
             }

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/sync/GossipSyncManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/sync/GossipSyncManager.kt
@@ -32,11 +32,16 @@ internal class GossipSyncManager(
     private val trafficLog: MeshTrafficLog? = null,
     private val dispatchers: AppDispatchers = AppDispatchers(),
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    private val requestSyncManager: RequestSyncManager = RequestSyncManager(nowMs = nowMillis),
 ) {
+    /** Exposed so BLE ingress / SecurityManager share the same pending-request window. */
+    fun isValidSyncResponse(peerID: String): Boolean =
+        requestSyncManager.isValidResponse(peerID = peerID, isRSR = true)
     interface Delegate {
         fun sendPacket(packet: BitchatPacket)
         fun sendPacketToPeer(peerID: String, packet: BitchatPacket)
         fun signPacketForBroadcast(packet: BitchatPacket): BitchatPacket
+        fun getConnectedPeers(): List<String> = emptyList()
     }
 
     interface ConfigProvider {
@@ -134,6 +139,7 @@ internal class GossipSyncManager(
                     delay(SyncDefaults.CLEANUP_INTERVAL_MS.milliseconds)
                     pruneStaleAnnouncements()
                     responseRateLimiter.prune(nowMillis())
+                    requestSyncManager.cleanup()
                 } catch (e: CancellationException) { throw e }
                 catch (e: Exception) { Log.e(TAG, "Periodic cleanup error: ${e.message}") }
             }
@@ -225,8 +231,16 @@ internal class GossipSyncManager(
     }
 
     private fun sendRequestSync(types: SyncTypeFlags = SyncTypeFlags.publicMessages) {
+        // Prefer unicast to connected peers so RSR can be attributed (iOS sendPeriodicSync).
+        val connected = delegate?.getConnectedPeers().orEmpty()
+        if (connected.isNotEmpty()) {
+            for (peerID in connected) {
+                sendRequestSyncToPeer(peerID, types)
+            }
+            return
+        }
+        // Discovery fallback: broadcast without solicitation registry (no peer to attribute).
         val payload = buildGcsPayload(types)
-
         val packet = BitchatPacket(
             type = MessageType.REQUEST_SYNC.value,
             senderID = peerIdToRoutingBytes(myPeerID),
@@ -234,12 +248,14 @@ internal class GossipSyncManager(
             payload = payload,
             ttl = SyncDefaults.SYNC_TTL_HOPS // neighbors only
         )
-        // Sign and broadcast
         val signed = delegate?.signPacketForBroadcast(packet) ?: packet
         delegate?.sendPacket(signed)
     }
 
-    private fun sendRequestSyncToPeer(peerID: String) {
+    private fun sendRequestSyncToPeer(
+        peerID: String,
+        types: SyncTypeFlags = allSyncTypes(),
+    ) {
         // Re-check at send time: the delayed job may fire after another path (or a
         // previous job) already sent a request to this peer within the interval.
         val now = nowMillis()
@@ -249,8 +265,10 @@ internal class GossipSyncManager(
             return
         }
         lastSyncRequestSentAt[peerID] = now
+        // Register solicitation so inbound RSR from this peer passes the ingress gate.
+        requestSyncManager.registerRequest(peerID)
 
-        val payload = buildGcsPayload(allSyncTypes())
+        val payload = buildGcsPayload(types)
 
         val packet = BitchatPacket(
             type = MessageType.REQUEST_SYNC.value,

--- a/transport/mesh/src/commonMain/kotlin/com/app/transport/sync/RequestSyncManager.kt
+++ b/transport/mesh/src/commonMain/kotlin/com/app/transport/sync/RequestSyncManager.kt
@@ -1,0 +1,63 @@
+package com.app.transport.sync
+
+import co.touchlab.stately.concurrency.Lock
+import co.touchlab.stately.concurrency.withLock
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Outgoing REQUEST_SYNC solicitation window for validating inbound RSR packets.
+ *
+ * Port of iOS `RequestSyncManager`: only peers we recently asked for sync may deliver
+ * `isRSR` frames, and only within [responseWindowMs] (default 30s).
+ */
+@OptIn(ExperimentalTime::class)
+class RequestSyncManager(
+    private val responseWindowMs: Long = DEFAULT_RESPONSE_WINDOW_MS,
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    companion object {
+        const val DEFAULT_RESPONSE_WINDOW_MS: Long = 30_000L
+    }
+
+    private val lock = Lock()
+    private val pendingRequests = mutableMapOf<String, Long>()
+
+    /** Register that we are sending a sync request to [peerID]. */
+    fun registerRequest(peerID: String) {
+        val now = nowMs()
+        lock.withLock {
+            pendingRequests[peerID] = now
+        }
+    }
+
+    /**
+     * Whether an inbound packet from [peerID] is a valid solicited RSR.
+     * Non-RSR always returns false (caller should not invoke for normal traffic).
+     */
+    fun isValidResponse(peerID: String, isRSR: Boolean): Boolean {
+        if (!isRSR) return false
+        val now = nowMs()
+        return lock.withLock {
+            val requestTime = pendingRequests[peerID] ?: return@withLock false
+            now - requestTime <= responseWindowMs
+        }
+    }
+
+    /** Drop expired pending requests (iOS periodic cleanup). */
+    fun cleanup() {
+        val now = nowMs()
+        lock.withLock {
+            val iter = pendingRequests.entries.iterator()
+            while (iter.hasNext()) {
+                val entry = iter.next()
+                if (now - entry.value > responseWindowMs) {
+                    iter.remove()
+                }
+            }
+        }
+    }
+
+    /** Test/debug only. */
+    internal fun debugPendingRequestCount(): Int = lock.withLock { pendingRequests.size }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerLogicalOriginTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerLogicalOriginTest.kt
@@ -1,0 +1,143 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.app.transport.mesh
+
+import com.app.transport.MeshConstants
+import com.app.transport.NoOpMeshTelemetry
+import com.app.transport.model.RoutedPacket
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * P0.1: multi-hop frames must keep [RoutedPacket.peerID] as the claimed logical origin
+ * (for signature/Noise), not the previous radio hop bound on the ingress link.
+ */
+class BleBearerLogicalOriginTest {
+
+    private val localPeer = "0a0b0c0d0e0f1011"
+    private val originPeer = "aaaaaaaaaaaaaaaa"
+    private val hopPeer = "bbbbbbbbbbbbbbbb"
+    private val linkAddress = "link-hop-1"
+
+    private class FakeTransport : BearerTransport {
+        override var delegate: BearerTransportDelegate? = null
+        override val addressPeerMap: MutableMap<String, String> = mutableMapOf()
+        override fun startServices(): Boolean = true
+        override fun stopServices() {}
+        override fun broadcastPacket(routed: RoutedPacket) {}
+        override fun sendToPeer(peerID: String, routed: RoutedPacket): Boolean = true
+        override fun cancelTransfer(transferId: String): Boolean = true
+        override fun isClientConnection(address: String): Boolean? = true
+        override fun setNicknameResolver(resolver: (String) -> String?) {}
+        override fun setMeshServiceActive(active: Boolean) {}
+        override fun setAppIsActive(active: Boolean) {}
+        override fun startServer() {}
+        override fun stopServer() {}
+        override fun startClient() {}
+        override fun stopClient() {}
+        override fun getConnectedDeviceEntries(): List<Triple<String, Boolean, Int?>> = emptyList()
+        override fun getLocalAdapterAddress(): String? = null
+        override fun connectToAddress(address: String): Boolean = true
+        override fun disconnectAddress(address: String) {}
+        override fun getDebugInfo(): String = ""
+    }
+
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
+
+    private fun messageFromOrigin(): BitchatPacket = BitchatPacket(
+        version = 1u,
+        type = MessageType.MESSAGE.value,
+        senderID = peerIdToRoutingBytes(originPeer),
+        recipientID = null,
+        timestamp = nowMs().toULong(),
+        payload = "relayed".encodeToByteArray(),
+        signature = null,
+        ttl = (MeshConstants.MESSAGE_TTL_HOPS - 1u).toUByte(),
+    )
+
+    @Test
+    fun multiHopMessage_preservesLogicalOriginInPeerID() = runBlocking {
+        val transport = FakeTransport()
+        // Link is bound to the previous hop, not the message author.
+        transport.addressPeerMap[linkAddress] = hopPeer
+
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        val delegate = requireNotNull(transport.delegate)
+
+        delegate.onPacketReceived(messageFromOrigin(), hopPeer, linkAddress)
+
+        val routed = withTimeoutOrNull(2_000) { bearer.incoming.first() }
+        assertNotNull(routed)
+        assertEquals(
+            originPeer,
+            routed.peerID,
+            "peerID must be claimed origin for crypto, not the previous hop",
+        )
+        assertEquals(linkAddress, routed.relayAddress)
+        assertEquals(
+            hopPeer,
+            routed.previousHopPeerID,
+            "previous hop must still be available as local metadata",
+        )
+    }
+
+    @Test
+    fun unboundLink_peerIDIsClaimedSender() = runBlocking {
+        val transport = FakeTransport()
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        val delegate = requireNotNull(transport.delegate)
+
+        delegate.onPacketReceived(messageFromOrigin(), originPeer, linkAddress)
+
+        val routed = withTimeoutOrNull(2_000) { bearer.incoming.first() }
+        assertNotNull(routed)
+        assertEquals(originPeer, routed.peerID)
+        // With no bind, receivedFrom falls back to claimed sender.
+        assertEquals(originPeer, routed.previousHopPeerID)
+    }
+
+    @Test
+    fun selfLoopback_isDropped() = runBlocking {
+        val transport = FakeTransport()
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        val delegate = requireNotNull(transport.delegate)
+        val selfPacket = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(localPeer),
+            recipientID = null,
+            timestamp = nowMs().toULong(),
+            payload = "me".encodeToByteArray(),
+            signature = null,
+            ttl = 7u,
+        )
+        delegate.onPacketReceived(selfPacket, localPeer, linkAddress)
+        val routed = withTimeoutOrNull(300) { bearer.incoming.first() }
+        assertNull(routed)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerRedundantLinkTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerRedundantLinkTest.kt
@@ -18,9 +18,12 @@ class BleBearerRedundantLinkTest {
         override val addressPeerMap: MutableMap<String, String> = mutableMapOf()
         var clientLinks: MutableList<BleClientLinkSnapshot> = mutableListOf()
         val disconnected = mutableListOf<String>()
+        var stopCalls = 0
+        var shutdownCalls = 0
 
         override fun startServices(): Boolean = true
-        override fun stopServices() {}
+        override fun stopServices() { stopCalls++ }
+        override fun shutdown() { shutdownCalls++ }
         override fun broadcastPacket(routed: RoutedPacket) {}
         override fun sendToPeer(peerID: String, routed: RoutedPacket): Boolean = true
         override fun cancelTransfer(transferId: String): Boolean = true
@@ -44,6 +47,27 @@ class BleBearerRedundantLinkTest {
         }
         override fun getDebugInfo(): String = ""
         override fun clientLinkSnapshots(): List<BleClientLinkSnapshot> = clientLinks.toList()
+    }
+
+    @Test
+    fun stopUsesTerminalTransportShutdown() {
+        val transport = FakeTransport()
+
+        bearer(transport).stop()
+
+        assertEquals(1, transport.shutdownCalls)
+        assertEquals(0, transport.stopCalls)
+    }
+
+    @Test
+    fun resetShutsDownOldTransportGeneration() {
+        val transport = FakeTransport()
+        val bearer = bearer(transport)
+
+        bearer.reset("2222222222222222")
+
+        assertEquals(1, transport.shutdownCalls)
+        assertEquals(0, transport.stopCalls)
     }
 
     private fun bearer(

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerRedundantLinkTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerRedundantLinkTest.kt
@@ -1,0 +1,123 @@
+package com.app.transport.mesh
+
+import com.app.transport.NoOpMeshTelemetry
+import com.app.transport.model.RoutedPacket
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Wiring test: [BleBearer.bindPeer] retires redundant central-role links via
+ * [BleRedundantLinkPolicy] + [BearerTransport.disconnectAddress].
+ */
+class BleBearerRedundantLinkTest {
+
+    private class FakeTransport : BearerTransport {
+        override var delegate: BearerTransportDelegate? = null
+        override val addressPeerMap: MutableMap<String, String> = mutableMapOf()
+        var clientLinks: MutableList<BleClientLinkSnapshot> = mutableListOf()
+        val disconnected = mutableListOf<String>()
+
+        override fun startServices(): Boolean = true
+        override fun stopServices() {}
+        override fun broadcastPacket(routed: RoutedPacket) {}
+        override fun sendToPeer(peerID: String, routed: RoutedPacket): Boolean = true
+        override fun cancelTransfer(transferId: String): Boolean = true
+        override fun isClientConnection(address: String): Boolean? =
+            if (clientLinks.any { it.address == address }) true else false
+
+        override fun setNicknameResolver(resolver: (String) -> String?) {}
+        override fun setMeshServiceActive(active: Boolean) {}
+        override fun setAppIsActive(active: Boolean) {}
+        override fun startServer() {}
+        override fun stopServer() {}
+        override fun startClient() {}
+        override fun stopClient() {}
+        override fun getConnectedDeviceEntries(): List<Triple<String, Boolean, Int?>> = emptyList()
+        override fun getLocalAdapterAddress(): String? = null
+        override fun connectToAddress(address: String): Boolean = true
+        override fun disconnectAddress(address: String) {
+            disconnected += address
+            clientLinks.removeAll { it.address == address }
+            addressPeerMap.remove(address)
+        }
+        override fun getDebugInfo(): String = ""
+        override fun clientLinkSnapshots(): List<BleClientLinkSnapshot> = clientLinks.toList()
+    }
+
+    private fun bearer(
+        transport: FakeTransport,
+        cooldownMs: Long = 60_000L,
+        clock: () -> Long = { 1_000_000L },
+    ): BleBearer {
+        return BleBearer(
+            myPeerID = "1111111111111111",
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            radioConfig = BleRadioConfig(linkRebindCooldownMs = cooldownMs),
+            nowMs = clock,
+        )
+    }
+
+    @Test
+    fun bindPeer_retiresDuplicateClientLink_keepingIngress() {
+        val transport = FakeTransport()
+        transport.clientLinks += listOf(
+            BleClientLinkSnapshot("link-old", peerID = "peerA", isConnected = true, hasCharacteristic = true),
+            BleClientLinkSnapshot("link-new", peerID = null, isConnected = true, hasCharacteristic = true),
+        )
+        transport.addressPeerMap["link-old"] = "peerA"
+
+        val b = bearer(transport)
+        b.bindPeer("peerA", "link-new")
+
+        assertEquals("peerA", transport.addressPeerMap["link-new"])
+        assertFalse(transport.addressPeerMap.containsKey("link-old"))
+        assertEquals(listOf("link-old"), transport.disconnected)
+        assertTrue(b.neighbors.value.none { it.deviceAddress == "link-old" })
+        assertTrue(b.neighbors.value.any { it.deviceAddress == "link-new" && it.peerID == "peerA" })
+    }
+
+    @Test
+    fun bindPeer_cooldownSuppressesSecondRetirement() {
+        val transport = FakeTransport()
+        var now = 1_000_000L
+        val b = bearer(transport, cooldownMs = 60_000L, clock = { now })
+
+        transport.clientLinks += listOf(
+            BleClientLinkSnapshot("a", peerID = "peerA", isConnected = true, hasCharacteristic = true),
+            BleClientLinkSnapshot("b", peerID = "peerA", isConnected = true, hasCharacteristic = true),
+        )
+        b.bindPeer("peerA", "b")
+        assertEquals(1, transport.disconnected.size)
+
+        // Re-introduce a third duplicate within cooldown — must not retire again.
+        transport.disconnected.clear()
+        transport.clientLinks += BleClientLinkSnapshot("c", peerID = "peerA", isConnected = true, hasCharacteristic = true)
+        transport.addressPeerMap["c"] = "peerA"
+        b.bindPeer("peerA", "c")
+        assertTrue(transport.disconnected.isEmpty())
+
+        // After cooldown, retirement runs again.
+        now += 60_001L
+        transport.clientLinks = mutableListOf(
+            BleClientLinkSnapshot("b", peerID = "peerA", isConnected = true, hasCharacteristic = true),
+            BleClientLinkSnapshot("c", peerID = "peerA", isConnected = true, hasCharacteristic = true),
+            BleClientLinkSnapshot("d", peerID = "peerA", isConnected = true, hasCharacteristic = true),
+        )
+        b.bindPeer("peerA", "d")
+        assertTrue(transport.disconnected.isNotEmpty())
+        assertEquals("peerA", transport.addressPeerMap["d"])
+    }
+
+    @Test
+    fun singleClientLink_noDisconnect() {
+        val transport = FakeTransport()
+        transport.clientLinks += BleClientLinkSnapshot("only", peerID = null, isConnected = true, hasCharacteristic = true)
+        val b = bearer(transport)
+        b.bindPeer("peerA", "only")
+        assertTrue(transport.disconnected.isEmpty())
+        assertEquals("peerA", transport.addressPeerMap["only"])
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerRsrIngressTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleBearerRsrIngressTest.kt
@@ -1,0 +1,145 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.app.transport.mesh
+
+import com.app.transport.NoOpMeshTelemetry
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * P0.2: BLE ingress must accept solicited RSR and drop unsolicited RSR.
+ * Multi-hop RSR must keep [RoutedPacket.peerID] as the logical author while
+ * solicitation is checked against the previous hop.
+ */
+class BleBearerRsrIngressTest {
+
+    private val localPeer = "0a0b0c0d0e0f1011"
+    private val hopPeer = "bbbbbbbbbbbbbbbb"
+    private val originPeer = "aaaaaaaaaaaaaaaa"
+    private val linkAddress = "link-rsr-1"
+
+    private class FakeTransport : BearerTransport {
+        override var delegate: BearerTransportDelegate? = null
+        override val addressPeerMap: MutableMap<String, String> = mutableMapOf()
+        override fun startServices(): Boolean = true
+        override fun stopServices() {}
+        override fun broadcastPacket(routed: com.app.transport.model.RoutedPacket) {}
+        override fun sendToPeer(peerID: String, routed: com.app.transport.model.RoutedPacket): Boolean = true
+        override fun cancelTransfer(transferId: String): Boolean = true
+        override fun isClientConnection(address: String): Boolean? = true
+        override fun setNicknameResolver(resolver: (String) -> String?) {}
+        override fun setMeshServiceActive(active: Boolean) {}
+        override fun setAppIsActive(active: Boolean) {}
+        override fun startServer() {}
+        override fun stopServer() {}
+        override fun startClient() {}
+        override fun stopClient() {}
+        override fun getConnectedDeviceEntries(): List<Triple<String, Boolean, Int?>> = emptyList()
+        override fun getLocalAdapterAddress(): String? = null
+        override fun connectToAddress(address: String): Boolean = true
+        override fun disconnectAddress(address: String) {}
+        override fun getDebugInfo(): String = ""
+    }
+
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
+
+    /** Old timestamp would fail 120s skew if RSR gate were bypassed incorrectly. */
+    private fun oldRsrPacket(): BitchatPacket = BitchatPacket(
+        version = 1u,
+        type = MessageType.MESSAGE.value,
+        senderID = peerIdToRoutingBytes(originPeer),
+        recipientID = null,
+        timestamp = (nowMs() - 600_000L).toULong(),
+        payload = "sync-replay".encodeToByteArray(),
+        signature = null,
+        ttl = 0u,
+        isRSR = true,
+    )
+
+    @Test
+    fun unsolicitedRsr_isDropped() = runBlocking {
+        val transport = FakeTransport()
+        transport.addressPeerMap[linkAddress] = hopPeer
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        // Default isValidSyncResponse = { false }
+        val delegate = requireNotNull(transport.delegate)
+        delegate.onPacketReceived(oldRsrPacket(), hopPeer, linkAddress)
+        val routed = withTimeoutOrNull(300) { bearer.incoming.first() }
+        assertNull(routed, "unsolicited RSR must not enter the mesh engine")
+        Unit
+    }
+
+    @Test
+    fun solicitedRsr_isAcceptedDespiteOldTimestamp() = runBlocking {
+        val transport = FakeTransport()
+        transport.addressPeerMap[linkAddress] = hopPeer
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        bearer.isValidSyncResponse = { peerID -> peerID == hopPeer }
+        val delegate = requireNotNull(transport.delegate)
+        delegate.onPacketReceived(oldRsrPacket(), hopPeer, linkAddress)
+        val routed = withTimeoutOrNull(2_000) { bearer.incoming.first() }
+        assertNotNull(routed, "solicited RSR must pass ingress even with old timestamp")
+        // hop (B) != author (C): peerID must remain logical author for signature/crypto.
+        assertEquals(originPeer, routed.peerID, "RSR peerID must be packet.senderID (author C)")
+        assertEquals(hopPeer, routed.previousHopPeerID, "RSR previous hop must be solicitation peer B")
+        Unit
+    }
+
+    @Test
+    fun solicitedRsr_wrongPeerStillDropped() = runBlocking {
+        val transport = FakeTransport()
+        transport.addressPeerMap[linkAddress] = hopPeer
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        // Window open for a different peer only.
+        bearer.isValidSyncResponse = { peerID -> peerID == "cccccccccccccccc" }
+        val delegate = requireNotNull(transport.delegate)
+        delegate.onPacketReceived(oldRsrPacket(), hopPeer, linkAddress)
+        val routed = withTimeoutOrNull(300) { bearer.incoming.first() }
+        assertNull(routed)
+        Unit
+    }
+
+    @Test
+    fun solicitedRsr_solicitationAgainstAuthorNotHop_isDropped() = runBlocking {
+        // Window open only for author C — real solicitation is registered on hop B.
+        val transport = FakeTransport()
+        transport.addressPeerMap[linkAddress] = hopPeer
+        val bearer = BleBearer(
+            myPeerID = localPeer,
+            debugSettingsManager = NoOpMeshTelemetry,
+            connectionManagerFactory = { transport },
+            nowMs = { nowMs() },
+        )
+        bearer.isValidSyncResponse = { peerID -> peerID == originPeer }
+        val delegate = requireNotNull(transport.delegate)
+        delegate.onPacketReceived(oldRsrPacket(), hopPeer, linkAddress)
+        val routed = withTimeoutOrNull(300) { bearer.incoming.first() }
+        assertNull(routed, "RSR gate must key on hop B, not author C")
+        Unit
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleDirectedRelaySpoolTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleDirectedRelaySpoolTest.kt
@@ -1,0 +1,67 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.SpecialRecipients
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BleDirectedRelaySpoolTest {
+
+    private fun packet(marker: UByte) = BitchatPacket(
+        type = MessageType.NOISE_ENCRYPTED.value,
+        senderID = ByteArray(8) { 0x11 },
+        recipientID = ByteArray(8) { 0x22 },
+        timestamp = marker.toULong(),
+        payload = byteArrayOf(marker.toByte()),
+        ttl = 7u,
+    )
+
+    @Test
+    fun enqueueDedupsByMessageId() {
+        val spool = BleDirectedRelaySpool()
+        val p = packet(1u)
+        assertTrue(spool.enqueue(p, "peerA", "mid-1", enqueuedAtMs = 1000L))
+        assertFalse(spool.enqueue(p, "peerA", "mid-1", enqueuedAtMs = 1001L))
+        assertEquals(1, spool.count)
+    }
+
+    @Test
+    fun drainReturnsOnlyUnexpiredAndClears() {
+        val spool = BleDirectedRelaySpool()
+        // now=10_000, window=5_000 → keep enqueuedAt >= 5_000
+        spool.enqueue(packet(1u), "peerA", "m1", enqueuedAtMs = 8_000L)
+        spool.enqueue(packet(2u), "peerB", "m2", enqueuedAtMs = 9_000L)
+        spool.enqueue(packet(3u), "peerC", "m3", enqueuedAtMs = 1_000L) // expired
+
+        val drained = spool.drainUnexpired(nowMs = 10_000L, windowMs = 5_000L)
+        assertEquals(2, drained.size)
+        assertEquals(setOf("peerA", "peerB"), drained.map { it.recipient }.toSet())
+        assertTrue(spool.isEmpty)
+        assertTrue(spool.drainUnexpired(nowMs = 10_000L, windowMs = 5_000L).isEmpty())
+    }
+
+    @Test
+    fun pruneExpiredKeepsFresh() {
+        val spool = BleDirectedRelaySpool()
+        spool.enqueue(packet(1u), "peerA", "m1", enqueuedAtMs = 1000L)
+        spool.enqueue(packet(2u), "peerA", "m2", enqueuedAtMs = 9000L)
+        spool.pruneExpired(nowMs = 10_000L, windowMs = 5_000L)
+        assertEquals(1, spool.count)
+        val left = spool.drainUnexpired(nowMs = 10_000L, windowMs = 5_000L)
+        assertEquals(listOf("m2"), left.map { "m2" }) // one entry remains conceptually
+        assertEquals(1, left.size)
+        assertEquals("peerA", left.single().recipient)
+    }
+
+    @Test
+    fun clearEmpties() {
+        val spool = BleDirectedRelaySpool()
+        spool.enqueue(packet(1u), "peerA", "m1", enqueuedAtMs = 1L)
+        spool.clear()
+        assertTrue(spool.isEmpty)
+        assertEquals(0, spool.count)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleIngressLinkRegistryTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleIngressLinkRegistryTest.kt
@@ -21,6 +21,17 @@ class BleIngressLinkRegistryTest {
         ttl = 7u,
     )
 
+    private fun packet(index: Int) = BitchatPacket(
+        version = 1u,
+        type = MessageType.MESSAGE.value,
+        senderID = peerIdToRoutingBytes("1111111111111111"),
+        recipientID = null,
+        timestamp = (1_700_000_000_000L + index).toULong(),
+        payload = byteArrayOf((index % 251).toByte()),
+        signature = null,
+        ttl = 7u,
+    )
+
     @Test
     fun recordIfNew_dedupsWithinLifetime() {
         val reg = BleIngressLinkRegistry()
@@ -52,5 +63,73 @@ class BleIngressLinkRegistryTest {
         reg.recordIfNew(packet(1), BleIngressLinkId.Central("c1"), "peerA", 1_000L, 3_000L)
         reg.prune(beforeMs = 2_000L)
         assertTrue(reg.isEmpty)
+    }
+
+    @Test
+    fun recordIfNew_hardCapEvictsOldestWhenAllFresh() {
+        val reg = BleIngressLinkRegistry()
+        val link = BleIngressLinkId.Peripheral("aa")
+        // lifetime huge so nothing is expired; still must not grow past MAX forever.
+        val lifetime = 1_000_000_000L
+        // Insert more than MAX_RECORDS with distinct payloads (via different timestamps).
+        val max = 4096
+        repeat(max + 50) { i ->
+            val p = packet(i)
+            reg.recordIfNew(p, link, "peerA", nowMs = 1_700_000_000_000L + i, lifetimeMs = lifetime)
+        }
+        assertEquals(max, reg.debugRecordCount())
+        val first = packet(0)
+        // If hard-capped correctly, FIFO removed the oldest insertion so it is new again.
+        assertTrue(
+            reg.recordIfNew(first, link, "peerA", nowMs = 1_700_000_000_000L + max + 100, lifetimeMs = lifetime),
+            "oldest insertion must be FIFO-evicted when over MAX_RECORDS",
+        )
+        assertEquals(max, reg.debugRecordCount())
+    }
+
+    @Test
+    fun hardCapPrunesExpiredBeforeFreshEntries() {
+        val reg = BleIngressLinkRegistry()
+        val link = BleIngressLinkId.Peripheral("aa")
+        val expired = packet(0)
+        reg.recordIfNew(expired, link, "peerA", nowMs = 0L, lifetimeMs = 100L)
+
+        repeat(4096) { i ->
+            reg.recordIfNew(packet(i + 1), link, "peerA", nowMs = 1_000L, lifetimeMs = 100L)
+        }
+
+        assertEquals(4096, reg.debugRecordCount())
+        assertEquals(null, reg.record(expired))
+        assertTrue(reg.record(packet(1)) != null)
+    }
+
+    @Test
+    fun readsAndRecentDuplicatesDoNotChangeFifoEvictionOrder() {
+        val reg = BleIngressLinkRegistry()
+        val link = BleIngressLinkId.Peripheral("aa")
+        val lifetime = Long.MAX_VALUE
+        repeat(4096) { i -> reg.recordIfNew(packet(i), link, "peerA", i.toLong(), lifetime) }
+
+        assertTrue(reg.record(packet(0)) != null)
+        assertFalse(reg.recordIfNew(packet(0), link, "peerA", 5_000L, lifetime))
+        reg.recordIfNew(packet(4096), link, "peerA", 5_001L, lifetime)
+
+        assertEquals(null, reg.record(packet(0)))
+        assertTrue(reg.record(packet(1)) != null)
+        assertEquals(4096, reg.debugRecordCount())
+    }
+
+    @Test
+    fun expiredRerecordMovesEntryToNewestFifoPosition() {
+        val reg = BleIngressLinkRegistry()
+        val link = BleIngressLinkId.Peripheral("aa")
+        repeat(4096) { i -> reg.recordIfNew(packet(i), link, "peerA", nowMs = 0L, lifetimeMs = 100L) }
+
+        assertTrue(reg.recordIfNew(packet(0), link, "peerA", nowMs = 1_000L, lifetimeMs = 100L))
+        reg.recordIfNew(packet(4096), link, "peerA", nowMs = 1_001L, lifetimeMs = 10_000L)
+
+        assertTrue(reg.record(packet(0)) != null, "re-recorded entry is a new FIFO insertion")
+        assertEquals(null, reg.record(packet(1)), "oldest unchanged insertion is evicted first")
+        assertEquals(4096, reg.debugRecordCount())
     }
 }

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleIngressLinkRegistryTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleIngressLinkRegistryTest.kt
@@ -1,0 +1,56 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BleIngressLinkRegistryTest {
+
+    private fun packet(payload: Byte = 1) = BitchatPacket(
+        version = 1u,
+        type = MessageType.MESSAGE.value,
+        senderID = peerIdToRoutingBytes("1111111111111111"),
+        recipientID = null,
+        timestamp = 1_700_000_000_000uL,
+        payload = byteArrayOf(payload),
+        signature = null,
+        ttl = 7u,
+    )
+
+    @Test
+    fun recordIfNew_dedupsWithinLifetime() {
+        val reg = BleIngressLinkRegistry()
+        val p = packet()
+        val link = BleIngressLinkId.Peripheral("aa")
+        assertTrue(reg.recordIfNew(p, link, "peerA", nowMs = 1_000L, lifetimeMs = 3_000L))
+        assertFalse(reg.recordIfNew(p, link, "peerA", nowMs = 2_000L, lifetimeMs = 3_000L))
+        // After lifetime, same message may be recorded again.
+        assertTrue(reg.recordIfNew(p, link, "peerA", nowMs = 5_000L, lifetimeMs = 3_000L))
+    }
+
+    @Test
+    fun messageIdStableForSamePacket() {
+        val p = packet(7)
+        assertEquals(BleIngressLinkRegistry.messageId(p), BleIngressLinkRegistry.messageId(p))
+    }
+
+    @Test
+    fun messageIdDiffersWhenPayloadDiffers() {
+        assertTrue(
+            BleIngressLinkRegistry.messageId(packet(1)) !=
+                BleIngressLinkRegistry.messageId(packet(2)),
+        )
+    }
+
+    @Test
+    fun pruneRemovesOldRecords() {
+        val reg = BleIngressLinkRegistry()
+        reg.recordIfNew(packet(1), BleIngressLinkId.Central("c1"), "peerA", 1_000L, 3_000L)
+        reg.prune(beforeMs = 2_000L)
+        assertTrue(reg.isEmpty)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleIngressPacketGuardTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleIngressPacketGuardTest.kt
@@ -1,0 +1,122 @@
+package com.app.transport.mesh
+
+import com.app.transport.MeshConstants
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BleIngressPacketGuardTest {
+
+    private val local = "0a0b0c0d0e0f1011"
+    private val peerA = "1111111111111111"
+    private val peerB = "2222222222222222"
+    private val now = 1_700_000_000_000L
+
+    private fun packet(
+        type: MessageType = MessageType.MESSAGE,
+        sender: String = peerA,
+        ttl: UByte = 7u,
+        timestampMs: Long = now,
+    ) = BitchatPacket(
+        version = 1u,
+        type = type.value,
+        senderID = peerIdToRoutingBytes(sender),
+        recipientID = null,
+        timestamp = timestampMs.toULong(),
+        payload = byteArrayOf(1, 2, 3),
+        signature = null,
+        ttl = ttl,
+    )
+
+    @Test
+    fun selfLoopbackDropped() {
+        val result = BleIngressPacketGuard.evaluate(
+            packet = packet(sender = local),
+            claimedSenderID = local,
+            boundPeerID = null,
+            localPeerID = local,
+            directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
+            nowMs = now,
+        )
+        assertIs<BleIngressPacketGuard.EvaluateResult.Reject>(result)
+        assertIs<BleIngressPacketGuard.Rejection.SelfLoopback>(result.rejection)
+    }
+
+    @Test
+    fun requestSyncOnBoundLink_requiresMatchingSender() {
+        val result = BleIngressPacketGuard.evaluate(
+            packet = packet(type = MessageType.REQUEST_SYNC, sender = peerB),
+            claimedSenderID = peerB,
+            boundPeerID = peerA,
+            localPeerID = local,
+            directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
+            nowMs = now,
+        )
+        assertIs<BleIngressPacketGuard.EvaluateResult.Reject>(result)
+        assertIs<BleIngressPacketGuard.Rejection.DirectSenderMismatch>(result.rejection)
+    }
+
+    @Test
+    fun directAnnounceOnBoundLink_attributesToClaimedSender() {
+        val result = BleIngressPacketGuard.evaluate(
+            packet = packet(
+                type = MessageType.ANNOUNCE,
+                sender = peerB,
+                ttl = MeshConstants.MESSAGE_TTL_HOPS,
+            ),
+            claimedSenderID = peerB,
+            boundPeerID = peerA,
+            localPeerID = local,
+            directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
+            nowMs = now,
+        )
+        val accept = assertIs<BleIngressPacketGuard.EvaluateResult.Accept>(result)
+        assertEquals(peerB, accept.context.receivedFromPeerID)
+        assertEquals(peerB, accept.context.validationPeerID)
+    }
+
+    @Test
+    fun boundLinkUsesBoundAsReceivedFrom() {
+        val result = BleIngressPacketGuard.evaluate(
+            packet = packet(sender = peerA),
+            claimedSenderID = peerA,
+            boundPeerID = peerA,
+            localPeerID = local,
+            directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
+            nowMs = now,
+        )
+        val accept = assertIs<BleIngressPacketGuard.EvaluateResult.Accept>(result)
+        assertEquals(peerA, accept.context.receivedFromPeerID)
+    }
+
+    @Test
+    fun timestampSkewRejected() {
+        val result = BleIngressPacketGuard.evaluate(
+            packet = packet(timestampMs = now - 200_000L),
+            claimedSenderID = peerA,
+            boundPeerID = null,
+            localPeerID = local,
+            directAnnounceTTL = MeshConstants.MESSAGE_TTL_HOPS,
+            nowMs = now,
+            maxTimestampSkewMs = 120_000L,
+        )
+        assertIs<BleIngressPacketGuard.EvaluateResult.Reject>(result)
+        assertIs<BleIngressPacketGuard.Rejection.TimestampSkew>(result.rejection)
+    }
+
+    @Test
+    fun validatePayloadAcceptsFreshTimestamp() {
+        assertNull(
+            BleIngressPacketGuard.validatePayload(
+                packet = packet(timestampMs = now - 1_000L),
+                peerID = peerA,
+                nowMs = now,
+            ),
+        )
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleLinkOutboundGoneTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleLinkOutboundGoneTest.kt
@@ -1,0 +1,38 @@
+package com.app.transport.mesh
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** P0.6: GONE must not be reported as a successful accept. */
+class BleLinkOutboundGoneTest {
+
+    @Test
+    fun submit_returnsFalseWhenLinkGoneOnFirstChunk() {
+        val buffer = BleLinkOutboundBuffer(onDrop = {})
+        val writer = BleChunkWriter { ChunkWriteResult.GONE }
+        val ok = buffer.submit(
+            frame = ByteArray(32) { 1 },
+            maxChunkBytes = 20,
+            writer = writer,
+            priority = BleOutboundPriority.RELAY_HIGH,
+            capBytes = 1_000_000,
+        )
+        assertFalse(ok)
+    }
+
+    @Test
+    fun submit_returnsTrueWhenAllChunksSent() {
+        val buffer = BleLinkOutboundBuffer(onDrop = {})
+        val writer = BleChunkWriter { ChunkWriteResult.SENT }
+        val ok = buffer.submit(
+            frame = ByteArray(10) { 1 },
+            maxChunkBytes = 64,
+            writer = writer,
+            priority = BleOutboundPriority.OWN_HIGH,
+            capBytes = 1_000_000,
+        )
+        assertTrue(ok)
+        assertTrue(buffer.isEmpty)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleNoiseSessionQueuesTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleNoiseSessionQueuesTest.kt
@@ -1,0 +1,84 @@
+package com.app.transport.mesh
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BleNoiseSessionQueuesTest {
+
+    @Test
+    fun privateMessages_fifoTakeAndEmpty() {
+        val q = BleNoiseSessionQueues()
+        q.appendPrivateMessage("a", "id-a", "peer1")
+        q.appendPrivateMessage("b", "id-b", "peer1")
+        assertFalse(q.isEmpty)
+
+        val taken = q.takePrivateMessages("peer1")
+        assertEquals(
+            listOf(
+                BleNoiseSessionQueues.PendingPrivateMessage("a", "id-a"),
+                BleNoiseSessionQueues.PendingPrivateMessage("b", "id-b"),
+            ),
+            taken,
+        )
+        assertTrue(q.takePrivateMessages("peer1").isEmpty())
+        assertTrue(q.isEmpty)
+    }
+
+    @Test
+    fun prependRestoresFailedMessagesAtFront() {
+        val q = BleNoiseSessionQueues()
+        q.appendPrivateMessage("new", "id-new", "peer1")
+        val failed = listOf(
+            BleNoiseSessionQueues.PendingPrivateMessage("old1", "id-1"),
+            BleNoiseSessionQueues.PendingPrivateMessage("old2", "id-2"),
+        )
+        q.prependPrivateMessages(failed, "peer1")
+        val taken = q.takePrivateMessages("peer1")
+        assertEquals(listOf("old1", "old2", "new"), taken.map { it.content })
+    }
+
+    @Test
+    fun typedPayloads_areCopiedOnAppend() {
+        val q = BleNoiseSessionQueues()
+        val buf = byteArrayOf(1, 2, 3)
+        q.appendTypedPayload(buf, "peer1")
+        buf[0] = 9
+        val taken = q.takeTypedPayloads("peer1")
+        assertEquals(1, taken.size)
+        assertEquals(byteArrayOf(1, 2, 3).toList(), taken[0].toList())
+    }
+
+    @Test
+    fun perPeerCapDropsOldestPrivateMessage() {
+        val q = BleNoiseSessionQueues(maxPrivateMessagesPerPeer = 2, maxTypedPayloadsPerPeer = 2, maxPeers = 8)
+        q.appendPrivateMessage("1", "id1", "peer1")
+        q.appendPrivateMessage("2", "id2", "peer1")
+        q.appendPrivateMessage("3", "id3", "peer1")
+        val taken = q.takePrivateMessages("peer1")
+        assertEquals(listOf("2", "3"), taken.map { it.content })
+    }
+
+    @Test
+    fun peerCapEvictsEldestPeer() {
+        val q = BleNoiseSessionQueues(maxPrivateMessagesPerPeer = 4, maxTypedPayloadsPerPeer = 4, maxPeers = 2)
+        q.appendPrivateMessage("a", "ida", "peerA")
+        q.appendPrivateMessage("b", "idb", "peerB")
+        q.appendPrivateMessage("c", "idc", "peerC") // evicts peerA
+        assertTrue(q.takePrivateMessages("peerA").isEmpty())
+        assertEquals(listOf("b"), q.takePrivateMessages("peerB").map { it.content })
+        assertEquals(listOf("c"), q.takePrivateMessages("peerC").map { it.content })
+    }
+
+    @Test
+    fun clearEmptiesBothQueues() {
+        val q = BleNoiseSessionQueues()
+        q.appendPrivateMessage("hi", "id", "peer1")
+        q.appendTypedPayload(byteArrayOf(0x01), "peer1")
+        q.clear()
+        assertTrue(q.isEmpty)
+        assertTrue(q.takePrivateMessages("peer1").isEmpty())
+        assertTrue(q.takeTypedPayloads("peer1").isEmpty())
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleNoiseSessionQueuesTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleNoiseSessionQueuesTest.kt
@@ -51,6 +51,19 @@ class BleNoiseSessionQueuesTest {
     }
 
     @Test
+    fun prependRestoresFailedTypedPayloadsAheadOfNewTraffic() {
+        val q = BleNoiseSessionQueues()
+        q.appendTypedPayload(byteArrayOf(3), "peer1")
+
+        q.prependTypedPayloads(listOf(byteArrayOf(1), byteArrayOf(2)), "peer1")
+
+        assertEquals(
+            listOf(listOf<Byte>(1), listOf<Byte>(2), listOf<Byte>(3)),
+            q.takeTypedPayloads("peer1").map(ByteArray::toList),
+        )
+    }
+
+    @Test
     fun perPeerCapDropsOldestPrivateMessage() {
         val q = BleNoiseSessionQueues(maxPrivateMessagesPerPeer = 2, maxTypedPayloadsPerPeer = 2, maxPeers = 8)
         q.appendPrivateMessage("1", "id1", "peer1")

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleRedundantLinkPolicyTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleRedundantLinkPolicyTest.kt
@@ -1,0 +1,151 @@
+package com.app.transport.mesh
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BleRedundantLinkPolicyTest {
+
+    private fun link(
+        uuid: String,
+        peerID: String? = "peerA",
+        connected: Boolean = true,
+        hasCharacteristic: Boolean = true,
+    ) = BleRedundantLinkPolicy.PeripheralLink(
+        uuid = uuid,
+        peerID = peerID,
+        isConnected = connected,
+        hasCharacteristic = hasCharacteristic,
+    )
+
+    @Test
+    fun singleBoundLink_returnsNullKeep() {
+        val links = listOf(link("u1"))
+        assertNull(
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = "u1",
+                mostRecentlyBoundUUID = "u1",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun prefersIngressWhenWritable() {
+        val links = listOf(link("u1"), link("u2"))
+        assertEquals(
+            "u1",
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = "u1",
+                mostRecentlyBoundUUID = "u2",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun fallsBackToMostRecentlyBound() {
+        val links = listOf(link("u1"), link("u2"))
+        assertEquals(
+            "u2",
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = null,
+                mostRecentlyBoundUUID = "u2",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun prefersWritableOverCharacteristicLess() {
+        val links = listOf(
+            link("u1", hasCharacteristic = false),
+            link("u2", hasCharacteristic = true),
+        )
+        // Ingress u1 is not writable while a writable candidate exists → not kept.
+        assertEquals(
+            "u2",
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = "u1",
+                mostRecentlyBoundUUID = "u2",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun whenOnlyNonWritableExist_allowsNonWritableKeep() {
+        val links = listOf(
+            link("u1", hasCharacteristic = false),
+            link("u2", hasCharacteristic = false),
+        )
+        assertEquals(
+            "u1",
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = "u1",
+                mostRecentlyBoundUUID = "u2",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun noViableAnchor_returnsNull() {
+        val links = listOf(link("u1"), link("u2"))
+        assertNull(
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = "other",
+                mostRecentlyBoundUUID = "also-other",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun ignoresOtherPeersAndDisconnected() {
+        val links = listOf(
+            link("u1", peerID = "peerA"),
+            link("u2", peerID = "peerB"),
+            link("u3", peerID = "peerA", connected = false),
+        )
+        // Only one connected peerA link → nothing to consolidate.
+        assertNull(
+            BleRedundantLinkPolicy.keptPeripheralUUID(
+                ingressPeripheralUUID = "u1",
+                mostRecentlyBoundUUID = "u1",
+                links = links,
+                peerID = "peerA",
+            ),
+        )
+    }
+
+    @Test
+    fun retireListExcludesKept() {
+        val links = listOf(link("u1"), link("u2"), link("u3"))
+        val retiring = BleRedundantLinkPolicy.peripheralUUIDsToRetire(
+            links = links,
+            peerID = "peerA",
+            keeping = "u2",
+        )
+        assertEquals(setOf("u1", "u3"), retiring.toSet())
+    }
+
+    @Test
+    fun retireListEmptyWhenOnlyKeptMatches() {
+        val links = listOf(link("u1"))
+        assertTrue(
+            BleRedundantLinkPolicy.peripheralUUIDsToRetire(
+                links = links,
+                peerID = "peerA",
+                keeping = "u1",
+            ).isEmpty(),
+        )
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleSelfBroadcastTrackerTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleSelfBroadcastTrackerTest.kt
@@ -1,0 +1,68 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.SpecialRecipients
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BleSelfBroadcastTrackerTest {
+
+    private fun packet(timestamp: ULong, payload: String = "message") = BitchatPacket(
+        version = 1u,
+        type = MessageType.MESSAGE.value,
+        senderID = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8),
+        recipientID = SpecialRecipients.BROADCAST,
+        timestamp = timestamp,
+        payload = payload.encodeToByteArray(),
+        signature = null,
+        ttl = 7u,
+    )
+
+    @Test
+    fun recordedIdIsTakenExactlyOnceForMatchingSelfReplay() {
+        val tracker = BleSelfBroadcastTracker()
+        val sent = packet(timestamp = 100u)
+
+        tracker.record(messageID = "LOCAL-UUID", packet = sent, sentAtMillis = 1_000)
+
+        assertEquals("LOCAL-UUID", tracker.takeMessageID(sent))
+        assertNull(tracker.takeMessageID(sent))
+    }
+
+    @Test
+    fun wireIdentityMatchesNativeSenderTimestampAndTypeKey() {
+        val tracker = BleSelfBroadcastTracker()
+        tracker.record("LOCAL-UUID", packet(timestamp = 100u, payload = "original"), 1_000)
+
+        assertEquals("LOCAL-UUID", tracker.takeMessageID(packet(timestamp = 100u, payload = "replayed")))
+    }
+
+    @Test
+    fun pruneAndClearRemoveStaleMappings() {
+        val tracker = BleSelfBroadcastTracker()
+        tracker.record("OLD", packet(100u), sentAtMillis = 1_000)
+        tracker.record("NEW", packet(101u), sentAtMillis = 2_000)
+
+        tracker.prune(beforeMillis = 1_500)
+        assertNull(tracker.takeMessageID(packet(100u)))
+        assertEquals("NEW", tracker.takeMessageID(packet(101u)))
+
+        tracker.record("LAST", packet(102u), sentAtMillis = 3_000)
+        tracker.clear()
+        assertNull(tracker.takeMessageID(packet(102u)))
+    }
+
+    @Test
+    fun capacityEvictsOldestInsertionDeterministically() {
+        val tracker = BleSelfBroadcastTracker(capacity = 2)
+        tracker.record("FIRST", packet(100u), sentAtMillis = 1_000)
+        tracker.record("SECOND", packet(101u), sentAtMillis = 2_000)
+        tracker.record("THIRD", packet(102u), sentAtMillis = 3_000)
+
+        assertNull(tracker.takeMessageID(packet(100u)))
+        assertEquals("SECOND", tracker.takeMessageID(packet(101u)))
+        assertEquals("THIRD", tracker.takeMessageID(packet(102u)))
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleSendCoreDirectedSpoolTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleSendCoreDirectedSpoolTest.kt
@@ -1,0 +1,117 @@
+package com.app.transport.mesh
+
+import com.app.transport.model.RoutedPacket
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.SpecialRecipients
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Directed packets must not be dropped while the radio has zero writable neighbors;
+ * they park in [BleDirectedRelaySpool] and leave after [BleSendCore.flushDirectedSpool].
+ */
+class BleSendCoreDirectedSpoolTest {
+
+    private companion object {
+        const val MY_PEER = "0a0b0c0d0e0f1011"
+        const val PEER = "1111111111111111"
+        const val ADDR = "link-1"
+    }
+
+    private class FakeRadio : BleRadioLink {
+        val links = mutableListOf<BleNeighbor>()
+        val emissions = mutableListOf<String>()
+
+        override fun neighbors(): List<BleNeighbor> = links.toList()
+        override fun peerForAddress(linkAddress: String): String? =
+            links.firstOrNull { it.linkAddress == linkAddress }?.peerID
+
+        override fun writeToNeighbor(neighbor: BleNeighbor, frame: ByteArray): Boolean {
+            emissions.add(neighbor.linkAddress)
+            return true
+        }
+    }
+
+    private fun directedPacket() = BitchatPacket(
+        version = 1u,
+        type = MessageType.NOISE_ENCRYPTED.value,
+        senderID = peerIdToRoutingBytes(MY_PEER),
+        recipientID = peerIdToRoutingBytes(PEER),
+        timestamp = 1_700_000_000_000uL,
+        payload = byteArrayOf(0x01, 0x02),
+        signature = null,
+        ttl = 7u,
+    )
+
+    private fun CoroutineScope.core(radio: FakeRadio) = BleSendCore(
+        scope = this,
+        fragmentManager = FragmentManager(),
+        transferProgressManager = TransferProgressManager(),
+        myPeerID = MY_PEER,
+        radio = radio,
+        trafficLog = null,
+        sourceRoutingEnabled = false,
+        logTag = "spool-test",
+    )
+
+    @Test
+    fun broadcastWhileNoLinks_spoolsThenFlushesOnLinkUp() = runTest {
+        val radio = FakeRadio()
+        val core = core(radio)
+
+        core.broadcastPacket(RoutedPacket(directedPacket(), directedPeerID = PEER))
+        advanceUntilIdle()
+        assertTrue(radio.emissions.isEmpty(), "no neighbors ⇒ nothing on the air yet")
+
+        radio.links += BleNeighbor(ADDR, isClient = true, peerID = PEER)
+        core.flushDirectedSpool()
+        advanceUntilIdle()
+
+        assertEquals(listOf(ADDR), radio.emissions)
+        core.shutdown()
+    }
+
+    @Test
+    fun broadcastWhileLinked_doesNotSpool() = runTest {
+        val radio = FakeRadio()
+        radio.links += BleNeighbor(ADDR, isClient = true, peerID = PEER)
+        val core = core(radio)
+
+        core.broadcastPacket(RoutedPacket(directedPacket(), directedPeerID = PEER))
+        advanceUntilIdle()
+        assertEquals(listOf(ADDR), radio.emissions)
+
+        core.flushDirectedSpool()
+        advanceUntilIdle()
+        assertEquals(1, radio.emissions.size)
+        core.shutdown()
+    }
+
+    @Test
+    fun publicBroadcastWithNoLinks_isNotSpoolFlushed() = runTest {
+        val radio = FakeRadio()
+        val core = core(radio)
+        val public = BitchatPacket(
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(MY_PEER),
+            recipientID = SpecialRecipients.BROADCAST,
+            timestamp = 1u,
+            payload = "hi".encodeToByteArray(),
+            ttl = 7u,
+        )
+        core.broadcastPacket(RoutedPacket(public))
+        advanceUntilIdle()
+
+        radio.links += BleNeighbor(ADDR, isClient = true, peerID = PEER)
+        core.flushDirectedSpool()
+        advanceUntilIdle()
+        assertTrue(radio.emissions.isEmpty(), "public traffic must not ride the directed spool")
+        core.shutdown()
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleSendCoreGoldenTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/BleSendCoreGoldenTest.kt
@@ -173,18 +173,21 @@ class BleSendCoreGoldenTest {
     }
 
     @Test
-    fun `directed send falls back to broadcast when write fails everywhere`() = runTest {
+    fun `directed send spools when write fails on recipient link`() = runTest {
         radio.failAddresses = setOf(ADDR_SRV_2)
         val core = core(sourceRouting = false)
         val p = packet(recipient = hexToBytes(PEER_SRV_2))
         core.broadcastPacket(RoutedPacket(p))
         advanceUntilIdle()
 
-        // Recipient link write failed -> historical fallback: broadcast, now through the
-        // P4 fanout subset; a chosen link whose write fails emits nothing.
-        val allLinks = listOf(ADDR_SRV_1, ADDR_SRV_2, ADDR_CLI_1, ADDR_CLI_2)
-        val expected = expectedBroadcastTargets(p, allLinks).filter { it != ADDR_SRV_2 }
-        assertEquals(expected, radio.emissions.map { it.first })
+        // P0.6: neighbor present but write returns false/GONE → spool, do not silent-flood.
+        assertTrue(radio.emissions.isEmpty(), "failed directed write must not flood other links")
+
+        // Recover the link and flush the directed spool — packet must leave.
+        radio.failAddresses = emptySet()
+        core.flushDirectedSpool()
+        advanceUntilIdle()
+        assertEquals(listOf(ADDR_SRV_2), radio.emissions.map { it.first })
         core.shutdown()
     }
 

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/CoreBluetoothRestoreIdsTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/CoreBluetoothRestoreIdsTest.kt
@@ -1,0 +1,13 @@
+package com.app.transport.mesh
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CoreBluetoothRestoreIdsTest {
+
+    @Test
+    fun identifiersMatchNativeAppForStateRestorationContinuity() {
+        assertEquals("chat.bitchat.ble.central", CoreBluetoothRestoreIds.CENTRAL)
+        assertEquals("chat.bitchat.ble.peripheral", CoreBluetoothRestoreIds.PERIPHERAL)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/FragmentIsRsrPropagationTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/FragmentIsRsrPropagationTest.kt
@@ -1,0 +1,49 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/** P0.2: fragment packets must inherit isRSR from the parent (iOS BLEOutboundFragmentPlanner). */
+class FragmentIsRsrPropagationTest {
+
+    @Test
+    fun createFragments_copiesIsRsrFlag() {
+        val largePayload = ByteArray(800) { it.toByte() }
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes("1122334455667788"),
+            recipientID = peerIdToRoutingBytes("8877665544332211"),
+            timestamp = 1_700_000_000_000uL,
+            payload = largePayload,
+            signature = null,
+            ttl = 7u,
+            isRSR = true,
+        )
+        val fragments = FragmentManager().createFragments(packet)
+        assertTrue(fragments.size > 1, "expected fragmentation for 800-byte payload")
+        assertTrue(fragments.all { it.isRSR }, "every fragment must carry isRSR=true")
+    }
+
+    @Test
+    fun createFragments_defaultIsRsrFalse() {
+        val largePayload = ByteArray(800) { it.toByte() }
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes("1122334455667788"),
+            recipientID = null,
+            timestamp = 1_700_000_000_000uL,
+            payload = largePayload,
+            signature = null,
+            ttl = 7u,
+            isRSR = false,
+        )
+        val fragments = FragmentManager().createFragments(packet)
+        assertTrue(fragments.size > 1)
+        assertTrue(fragments.none { it.isRSR })
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/FragmentOneMibFileInteropTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/FragmentOneMibFileInteropTest.kt
@@ -1,0 +1,87 @@
+package com.app.transport.mesh
+
+import com.app.transport.MeshConstants
+import com.app.transport.model.BitchatFilePacket
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * P0.4 boundary: exact 1 MiB incompressible content through createFragments → handleFragment
+ * → BitchatFilePacket.decode (framed packet > 1_048_576 bytes).
+ */
+class FragmentOneMibFileInteropTest {
+
+    @Test
+    fun exactOneMibFile_fragmentsAndReassembles() {
+        val size = MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES
+        // Incompressible pattern so compress path (if any) does not shrink below threshold.
+        val content = ByteArray(size) { (it * 17 + 31).toByte() }
+        val file = BitchatFilePacket(
+            fileName = "big.bin",
+            fileSize = size.toLong(),
+            mimeType = "application/octet-stream",
+            content = content,
+        )
+        val tlv = assertNotNull(file.encode())
+        val outer = BitchatPacket(
+            version = 2u,
+            type = MessageType.FILE_TRANSFER.value,
+            senderID = peerIdToRoutingBytes("1122334455667788"),
+            recipientID = peerIdToRoutingBytes("8877665544332211"),
+            timestamp = 1_700_000_000_000uL,
+            payload = tlv,
+            signature = ByteArray(64) { 0x11 },
+            ttl = 7u,
+        )
+        val encodedOuter = assertNotNull(outer.toBinaryData(padding = false))
+        assertTrue(
+            encodedOuter.size > MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES,
+            "framed packet must exceed bare 1 MiB content (was ${encodedOuter.size})",
+        )
+        assertTrue(
+            encodedOuter.size <= MeshConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES,
+            "framed packet ${encodedOuter.size} must fit fragment total cap " +
+                "${MeshConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES}",
+        )
+
+        // Round-trip the outer frame without fragmentation first.
+        val roundTrip = BitchatPacket.fromBinaryData(encodedOuter)
+        assertNotNull(roundTrip, "outer packet must decode before fragmentation")
+
+        val fm = FragmentManager()
+        val fragments = fm.createFragments(outer)
+        assertTrue(fragments.size > 1, "fragment count was ${fragments.size}")
+        assertTrue(
+            fragments.size <= MeshConstants.Fragmentation.MAX_FRAGMENTS_PER_ID,
+            "too many fragments: ${fragments.size}",
+        )
+
+        var reassembled: BitchatPacket? = null
+        var accepted = 0
+        for (fragment in fragments) {
+            val done = fm.handleFragment(fragment)
+            if (done != null) {
+                reassembled = done
+            } else {
+                // handleFragment returns null for intermediate pieces; count only via side effect.
+                accepted++
+            }
+        }
+        val full = assertNotNull(
+            reassembled,
+            "reassembly must complete for 1 MiB file " +
+                "(fragments=${fragments.size}, intermediateNulls=$accepted, " +
+                "encodedOuter=${encodedOuter.size})",
+        )
+        assertEquals(MessageType.FILE_TRANSFER.value, full.type)
+        val decodedFile = assertNotNull(BitchatFilePacket.decode(full.payload))
+        assertEquals(size, decodedFile.content.size)
+        assertEquals(content.toList().take(16), decodedFile.content.toList().take(16))
+        assertEquals(content.last(), decodedFile.content.last())
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/PrivateFileOuterPacketTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/PrivateFileOuterPacketTest.kt
@@ -1,0 +1,67 @@
+package com.app.transport.mesh
+
+import com.app.transport.model.BitchatFilePacket
+import com.app.transport.protocol.BinaryProtocol
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+/**
+ * P0.3: private file uses outer FILE_TRANSFER 0x22 with directed recipient and
+ * canonical BitchatFilePacket TLV (native BLEService.sendFilePrivate shape).
+ */
+class PrivateFileOuterPacketTest {
+
+    private val sender = "0a0b0c0d0e0f1011"
+    private val recipient = "1111111111111111"
+
+    @Test
+    fun outerFileTransfer_directedRoundTrip() {
+        val file = BitchatFilePacket(
+            fileName = "note.txt",
+            fileSize = 5L,
+            mimeType = "text/plain",
+            content = "hello".encodeToByteArray(),
+        )
+        val tlv = assertNotNull(file.encode())
+        val packet = BitchatPacket(
+            version = 2u,
+            type = MessageType.FILE_TRANSFER.value,
+            senderID = peerIdToRoutingBytes(sender),
+            recipientID = peerIdToRoutingBytes(recipient),
+            timestamp = 1_700_000_000_000uL,
+            payload = tlv,
+            signature = ByteArray(64) { 0x42 },
+            ttl = 7u,
+        )
+
+        assertEquals(MessageType.FILE_TRANSFER.value, packet.type)
+        assertEquals(0x22u.toUByte(), packet.type)
+        assertEquals(2u.toUByte(), packet.version)
+        assertNotNull(packet.recipientID)
+        assertContentEquals(peerIdToRoutingBytes(recipient), packet.recipientID)
+
+        val encoded = assertNotNull(BinaryProtocol.encode(packet, padding = false))
+        val decoded = assertNotNull(BinaryProtocol.decode(encoded))
+        assertEquals(MessageType.FILE_TRANSFER.value, decoded.type)
+        assertEquals(2u.toUByte(), decoded.version)
+        assertContentEquals(peerIdToRoutingBytes(recipient), decoded.recipientID)
+        val decodedFile = assertNotNull(BitchatFilePacket.decode(decoded.payload))
+        assertEquals("note.txt", decodedFile.fileName)
+        assertEquals("hello", decodedFile.content.decodeToString())
+        assertNotNull(decoded.signature)
+    }
+
+    @Test
+    fun outerPrivateFile_isNotNoiseEncryptedType() {
+        // Contract: native-compatible private file is plain directed 0x22, not Noise 0x11.
+        assertEquals(0x22u.toUByte(), MessageType.FILE_TRANSFER.value)
+        assertEquals(0x11u.toUByte(), MessageType.NOISE_ENCRYPTED.value)
+        assertFalse(MessageType.FILE_TRANSFER.value == MessageType.NOISE_ENCRYPTED.value)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/RsrLogicalOriginSecurityTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/RsrLogicalOriginSecurityTest.kt
@@ -1,0 +1,161 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * P0.2: solicitation peer for RSR is the hop (not the logical author).
+ * Pure guard tests without EncryptionService — SecurityManager wiring is covered
+ * in androidHostTest [RsrMultiHopSecurityManagerTest].
+ */
+class RsrLogicalOriginSecurityTest {
+
+    private val hopPeer = "bbbbbbbbbbbbbbbb"
+    private val authorPeer = "aaaaaaaaaaaaaaaa"
+    private val now = 1_700_000_000_000L
+
+    private fun oldRsrLeave() = BitchatPacket(
+        version = 1u,
+        type = MessageType.LEAVE.value,
+        senderID = peerIdToRoutingBytes(authorPeer),
+        recipientID = null,
+        timestamp = 1_000_000uL,
+        payload = byteArrayOf(),
+        signature = null,
+        ttl = 0u,
+        isRSR = true,
+    )
+
+    @Test
+    fun validatePayload_rsrUsesHopForSolicitation() {
+        val packet = oldRsrLeave()
+        // Gate open only for hop B
+        assertNull(
+            BleIngressPacketGuard.validatePayload(
+                packet = packet,
+                peerID = hopPeer,
+                nowMs = now,
+                isRSR = true,
+                isValidSyncResponse = { it == hopPeer },
+            ),
+        )
+        // Same packet keyed as author C → unsolicited
+        val rejected = BleIngressPacketGuard.validatePayload(
+            packet = packet,
+            peerID = authorPeer,
+            nowMs = now,
+            isRSR = true,
+            isValidSyncResponse = { it == hopPeer },
+        )
+        assertIs<BleIngressPacketGuard.Rejection.InvalidRSR>(rejected)
+        assertEquals(authorPeer, rejected.peerID)
+    }
+
+    @Test
+    fun packetContext_rsrValidationPeerIsHop_claimedSenderIsAuthor() {
+        val packet = oldRsrLeave()
+        val result = BleIngressLinkRegistry.packetContext(
+            packet = packet,
+            claimedSenderID = authorPeer,
+            boundPeerID = hopPeer,
+            localPeerID = "0a0b0c0d0e0f1011",
+            directAnnounceTTL = 7u,
+            isRSR = true,
+        )
+        val success = assertIs<BleIngressLinkRegistry.Companion.Result.Success>(result)
+        assertEquals(hopPeer, success.context.receivedFromPeerID)
+        assertEquals(hopPeer, success.context.validationPeerID, "ingress solicitation key")
+        // BleBearer must map claimedSenderID → RoutedPacket.peerID, not validationPeerID
+    }
+
+    @Test
+    fun selfAuthoredSyncResponse_onlyIsRsrTtlZero() {
+        val local = "0a0b0c0d0e0f1011"
+        val base = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(local),
+            recipientID = null,
+            timestamp = 1u,
+            payload = byteArrayOf(1),
+            signature = null,
+            ttl = 0u,
+            isRSR = true,
+        )
+        assertEquals(
+            true,
+            BleIngressLinkRegistry.isSelfAuthoredSyncResponse(base, local, local),
+        )
+        assertEquals(
+            false,
+            BleIngressLinkRegistry.isSelfAuthoredSyncResponse(
+                base.copy(isRSR = false), local, local,
+            ),
+        )
+        assertEquals(
+            false,
+            BleIngressLinkRegistry.isSelfAuthoredSyncResponse(
+                base.copy(ttl = 3u), local, local,
+            ),
+        )
+        assertEquals(
+            false,
+            BleIngressLinkRegistry.isSelfAuthoredSyncResponse(base, authorPeer, local),
+        )
+    }
+
+    @Test
+    fun packetContext_allowsSelfAuthoredRsr() {
+        val local = "0a0b0c0d0e0f1011"
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(local),
+            recipientID = null,
+            timestamp = 1u,
+            payload = byteArrayOf(1),
+            signature = null,
+            ttl = 0u,
+            isRSR = true,
+        )
+        val result = BleIngressLinkRegistry.packetContext(
+            packet = packet,
+            claimedSenderID = local,
+            boundPeerID = hopPeer,
+            localPeerID = local,
+            directAnnounceTTL = 7u,
+            isRSR = true,
+        )
+        assertIs<BleIngressLinkRegistry.Companion.Result.Success>(result)
+    }
+
+    @Test
+    fun packetContext_rejectsOrdinarySelfLoopback() {
+        val local = "0a0b0c0d0e0f1011"
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(local),
+            recipientID = null,
+            timestamp = 1u,
+            payload = byteArrayOf(1),
+            signature = null,
+            ttl = 3u,
+            isRSR = false,
+        )
+        val result = BleIngressLinkRegistry.packetContext(
+            packet = packet,
+            claimedSenderID = local,
+            boundPeerID = hopPeer,
+            localPeerID = local,
+            directAnnounceTTL = 7u,
+            isRSR = false,
+        )
+        assertIs<BleIngressLinkRegistry.Companion.Result.Failure>(result)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/SelfAuthoredFragmentSuppressionTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/mesh/SelfAuthoredFragmentSuppressionTest.kt
@@ -1,0 +1,54 @@
+package com.app.transport.mesh
+
+import com.app.transport.protocol.BitchatPacket
+import com.app.transport.protocol.MessageType
+import com.app.transport.protocol.peerIdToRoutingBytes
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * P1: self-authored fragments skip assembly (iOS BLEFragmentHandler).
+ * Policy unit test + remote assembly regression.
+ */
+class SelfAuthoredFragmentSuppressionTest {
+
+    private val local = "0a0b0c0d0e0f1011"
+    private val remote = "bbbbbbbbbbbbbbbb"
+
+    @Test
+    fun shouldAssemble_falseForSelfAuthor() {
+        assertFalse(BleFragmentIngressPolicy.shouldAssemble(local, local))
+        assertFalse(BleFragmentIngressPolicy.shouldAssemble(null, local))
+    }
+
+    @Test
+    fun shouldAssemble_trueForRemoteAuthor() {
+        assertTrue(BleFragmentIngressPolicy.shouldAssemble(remote, local))
+    }
+
+    @Test
+    fun remoteFragmentsStillAssemble() {
+        val fm = FragmentManager()
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = peerIdToRoutingBytes(remote),
+            recipientID = null,
+            timestamp = 1_700_000_000_000uL,
+            payload = ByteArray(800) { it.toByte() },
+            signature = null,
+            ttl = 0u,
+            isRSR = true,
+        )
+        val fragments = fm.createFragments(packet)
+        assertTrue(fragments.size > 1)
+        var done: BitchatPacket? = null
+        for (f in fragments) {
+            val r = fm.handleFragment(f)
+            if (r != null) done = r
+        }
+        assertNotNull(done)
+    }
+}

--- a/transport/mesh/src/commonTest/kotlin/com/app/transport/sync/RequestSyncManagerTest.kt
+++ b/transport/mesh/src/commonTest/kotlin/com/app/transport/sync/RequestSyncManagerTest.kt
@@ -1,0 +1,60 @@
+package com.app.transport.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** iOS RequestSyncManagerTests parity — pending-request window for RSR solicitation. */
+class RequestSyncManagerTest {
+
+    @Test
+    fun nonRsrIsNeverValid() {
+        var now = 1_000L
+        val manager = RequestSyncManager(responseWindowMs = 30_000L, nowMs = { now })
+        manager.registerRequest("aaaaaaaaaaaaaaaa")
+        assertFalse(manager.isValidResponse("aaaaaaaaaaaaaaaa", isRSR = false))
+    }
+
+    @Test
+    fun unsolicitedRsrRejected() {
+        val manager = RequestSyncManager(responseWindowMs = 30_000L, nowMs = { 1_000L })
+        assertFalse(manager.isValidResponse("bbbbbbbbbbbbbbbb", isRSR = true))
+    }
+
+    @Test
+    fun solicitedRsrAcceptedWithinWindow() {
+        var now = 1_000L
+        val manager = RequestSyncManager(responseWindowMs = 30_000L, nowMs = { now })
+        val peer = "cccccccccccccccc"
+        manager.registerRequest(peer)
+        now = 20_000L
+        assertTrue(manager.isValidResponse(peer, isRSR = true))
+    }
+
+    @Test
+    fun rsrOutsideWindowRejected() {
+        var now = 1_000L
+        val manager = RequestSyncManager(responseWindowMs = 30_000L, nowMs = { now })
+        val expired = "dddddddddddddddd"
+        val fresh = "eeeeeeeeeeeeeeee"
+        manager.registerRequest(expired)
+        now = 20_000L
+        manager.registerRequest(fresh)
+        now = 40_000L // expired at 1_000 is 39s old; fresh at 20_000 is 20s old
+        assertFalse(manager.isValidResponse(expired, isRSR = true))
+        assertTrue(manager.isValidResponse(fresh, isRSR = true))
+    }
+
+    @Test
+    fun cleanupRemovesExpired() {
+        var now = 1_000L
+        val manager = RequestSyncManager(responseWindowMs = 30_000L, nowMs = { now })
+        manager.registerRequest("ffffffffffffffff")
+        assertEquals(1, manager.debugPendingRequestCount())
+        now = 50_000L
+        manager.cleanup()
+        assertEquals(0, manager.debugPendingRequestCount())
+        assertFalse(manager.isValidResponse("ffffffffffffffff", isRSR = true))
+    }
+}

--- a/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
+++ b/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
@@ -300,6 +300,8 @@ internal class CoreBluetoothConnectionManager(
 
     override fun cancelTransfer(transferId: String): Boolean = sendCore.cancelTransfer(transferId)
 
+    override fun flushDirectedSpool() = sendCore.flushDirectedSpool()
+
     private inner class RadioLink : BleRadioLink {
         override fun neighbors(): List<BleNeighbor> =
             subscribedCentrals.keys.map { addr ->

--- a/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
+++ b/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
@@ -220,12 +220,17 @@ internal class CoreBluetoothConnectionManager(
             } catch (_: Exception) {
             }
         }
+        // Drop outbound buffers and peer bindings so a restart cannot write to dead links or
+        // attribute spoofed senders to stale NSUUIDs.
+        (connectedPeripherals.keys + subscribedCentrals.keys).forEach { outbound.dropLink(it) }
         connectedPeripherals.clear()
         peripheralCharacteristics.clear()
         pendingPeripherals.clear()
         discoveredPeripherals.clear()
         subscribedCentrals.clear()
         frameAssemblers.clear()
+        addressPeerMap.clear()
+        sendCore.pruneDirectedSpool()
     }
 
     fun shutdown() {
@@ -272,8 +277,8 @@ internal class CoreBluetoothConnectionManager(
 
     // -----------------------------------------------------------------
     // Send — shared BleSendCore (C1); only the raw CB writes below are Apple-specific.
-    // Source routing stays disabled here to preserve the pre-unification target set
-    // (the Apple bearer never source-routed); the owner can enable it deliberately.
+    // Source routing is enabled like Android: MeshOutboundSender attaches routes when the
+    // mesh graph has confirmed multi-hop paths; empty routes fall through to flood.
     // -----------------------------------------------------------------
 
     private val sendCore = BleSendCore(
@@ -283,7 +288,7 @@ internal class CoreBluetoothConnectionManager(
         myPeerID = myPeerID,
         radio = RadioLink(),
         trafficLog = null,
-        sourceRoutingEnabled = false,
+        sourceRoutingEnabled = true,
         logTag = TAG,
         config = config,
     )
@@ -400,15 +405,26 @@ internal class CoreBluetoothConnectionManager(
 
         override fun centralManager(central: CBCentralManager, willRestoreState: Map<Any?, *>) {
             // Re-adopt peripherals iOS handed back after relaunching us: rebind our delegate and
-            // rediscover the mesh service so the links resume. On-device-only behavior.
+            // rediscover the mesh service / characteristic so the links resume writable.
+            // Restored connections often lack a cached characteristic (iOS reference does the same
+            // rediscovery) — without this step dual-role restore multiplies dead links.
             @Suppress("UNCHECKED_CAST")
             val restored = willRestoreState[CBCentralManagerRestoredStatePeripheralsKey] as? List<CBPeripheral> ?: return
             restored.forEach { peripheral ->
                 val addr = peripheral.identifier.UUIDString
                 peripheral.delegate = this
                 discoveredPeripherals.put(addr, peripheral)
+                // Already-connected restored links go into the connected map once the characteristic
+                // rediscovers; pending keeps them visible to the scheduler until then.
                 pendingPeripherals.put(addr, peripheral)
-                peripheral.discoverServices(listOf(serviceCbUuid))
+                if (peripheral.services?.any { (it as? CBService)?.UUID == serviceCbUuid } == true) {
+                    val service = peripheral.services!!
+                        .filterIsInstance<CBService>()
+                        .first { it.UUID == serviceCbUuid }
+                    peripheral.discoverCharacteristics(listOf(characteristicCbUuid), service)
+                } else {
+                    peripheral.discoverServices(listOf(serviceCbUuid))
+                }
             }
         }
 
@@ -483,19 +499,51 @@ internal class CoreBluetoothConnectionManager(
             didDiscoverCharacteristicsForService: CBService,
             error: NSError?,
         ) {
+            if (error != null) {
+                Log.w(TAG, "Characteristic discovery failed: ${error.localizedDescription}")
+                return
+            }
             val char = didDiscoverCharacteristicsForService.characteristics
                 ?.filterIsInstance<CBCharacteristic>()
                 ?.firstOrNull { it.UUID == characteristicCbUuid } ?: return
             val addr = peripheral.identifier.UUIDString
+            // Cache early so clientLinkSnapshots reports hasCharacteristic during notify setup.
             connectedPeripherals.put(addr, peripheral)
             peripheralCharacteristics.put(addr, char)
             pendingPeripherals.remove(addr)
             discoveredPeripherals.remove(addr)
+            // Link is fully write/notify-ready only after subscription confirms (below).
             peripheral.setNotifyValue(true, char)
-            centralPolicy.onConnected(addr)
-            delegate?.onDeviceConnected(addr)
         }
 
+        /**
+         * Notify subscription confirmed (or failed). iOS reference flushes directed spool and
+         * treats the peer as connected only after this — writing before notify is enabled is racy.
+         */
+        @ObjCSignatureOverride
+        override fun peripheral(
+            peripheral: CBPeripheral,
+            didUpdateNotificationStateForCharacteristic: CBCharacteristic,
+            error: NSError?,
+        ) {
+            val addr = peripheral.identifier.UUIDString
+            if (error != null) {
+                Log.w(TAG, "Notify enable failed for ${addr.take(8)}…: ${error.localizedDescription}")
+                return
+            }
+            if (didUpdateNotificationStateForCharacteristic.UUID != characteristicCbUuid) return
+            if (connectedPeripherals.get(addr) == null) {
+                connectedPeripherals.put(addr, peripheral)
+            }
+            peripheralCharacteristics.put(addr, didUpdateNotificationStateForCharacteristic)
+            centralPolicy.onConnected(addr)
+            delegate?.onDeviceConnected(addr)
+            // Belt-and-suspenders: BleBearer also flushes on LinkConnected; call here so
+            // a platform that skips the bearer still drains the spool when the link is writable.
+            sendCore.flushDirectedSpool()
+        }
+
+        @ObjCSignatureOverride
         override fun peripheral(
             peripheral: CBPeripheral,
             didUpdateValueForCharacteristic: CBCharacteristic,
@@ -558,6 +606,8 @@ internal class CoreBluetoothConnectionManager(
             val addr = central.identifier.UUIDString
             subscribedCentrals.put(addr, central)
             delegate?.onDeviceConnected(addr)
+            // Server-role link is now notify-writable — drain directed spool (iOS post-subscribe).
+            sendCore.flushDirectedSpool()
         }
 
         @ObjCSignatureOverride
@@ -600,8 +650,12 @@ internal class CoreBluetoothConnectionManager(
     // are no-ops/empty on Apple (they only back the Android debug sheet).
     // -----------------------------------------------------------------
 
-    override fun setNicknameResolver(resolver: (String) -> String?) = Unit
+    override fun setNicknameResolver(resolver: (String) -> String?) {
+        sendCore.setNicknameResolver(resolver)
+    }
+
     override fun setMeshServiceActive(active: Boolean) = Unit
+
     override fun setAppIsActive(active: Boolean) {
         val changed = appActivityLock.withLock {
             if (appIsActive == active) false else {
@@ -609,7 +663,11 @@ internal class CoreBluetoothConnectionManager(
                 true
             }
         }
-        if (changed) scope.launch { centralPolicy.onAppActivityChanged() }
+        if (changed) {
+            // Re-apply scan duty and prune expired directed spool on foreground/background.
+            sendCore.pruneDirectedSpool()
+            scope.launch { centralPolicy.onAppActivityChanged() }
+        }
     }
     override fun startServer() = Unit
     override fun stopServer() = Unit
@@ -656,6 +714,14 @@ internal class CoreBluetoothConnectionManager(
         }
     }
 
-    override fun getDebugInfo(): String =
-        "CoreBluetooth: peripherals=${connectedPeripherals.size}, centrals=${subscribedCentrals.size}, active=$active"
+    override fun getDebugInfo(): String = buildString {
+        appendLine("CoreBluetooth dual-role")
+        appendLine("active=$active")
+        appendLine("client peripherals=${connectedPeripherals.size} (writable=${peripheralCharacteristics.size})")
+        appendLine("server centrals=${subscribedCentrals.size}")
+        appendLine("pending connects=${pendingPeripherals.size}")
+        appendLine("discovered candidates=${discoveredPeripherals.size}")
+        appendLine("addressPeerMap=${addressPeerMap.size}")
+        append(sendCore.getDebugInfo())
+    }
 }

--- a/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
+++ b/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
@@ -618,9 +618,42 @@ internal class CoreBluetoothConnectionManager(
         connectedPeripherals.keys.map { Triple(it, true, null) } +
                 subscribedCentrals.keys.map { Triple(it, false, null) }
 
+    /**
+     * Central-role (CBPeripheral we connected to) links only — [BleRedundantLinkPolicy] input.
+     * Server-role CBCentral subscriptions are omitted.
+     */
+    override fun clientLinkSnapshots(): List<BleClientLinkSnapshot> =
+        connectedPeripherals.keys.map { addr ->
+            BleClientLinkSnapshot(
+                address = addr,
+                peerID = addressPeerMap.get(addr),
+                isConnected = true,
+                hasCharacteristic = peripheralCharacteristics.get(addr) != null,
+            )
+        }
+
     override fun getLocalAdapterAddress(): String? = null
     override fun connectToAddress(address: String): Boolean = false
-    override fun disconnectAddress(address: String) = Unit
+
+    /**
+     * Cancels a central-role connection. Used by [BleBearer] redundant-link retirement and debug UI.
+     * Removes local bookkeeping first so the disconnect callback does not double-clean.
+     */
+    override fun disconnectAddress(address: String) {
+        val peripheral = connectedPeripherals.get(address) ?: pendingPeripherals.get(address) ?: return
+        connectedPeripherals.remove(address)
+        pendingPeripherals.remove(address)
+        peripheralCharacteristics.remove(address)
+        frameAssemblers.remove(address)
+        outbound.dropLink(address)
+        addressPeerMap.remove(address)
+        try {
+            centralManager.cancelPeripheralConnection(peripheral)
+        } catch (e: Exception) {
+            Log.w(TAG, "disconnectAddress($address) failed: ${e.message}")
+        }
+    }
+
     override fun getDebugInfo(): String =
         "CoreBluetooth: peripherals=${connectedPeripherals.size}, centrals=${subscribedCentrals.size}, active=$active"
 }

--- a/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
+++ b/transport/mesh/src/nativeMain/kotlin/com/app/transport/mesh/CoreBluetoothConnectionManager.kt
@@ -88,8 +88,6 @@ internal class CoreBluetoothConnectionManager(
         // State-restoration identifiers: let iOS relaunch the app into the background to hand back the
         // same central/peripheral managers (with their connections) after the process was killed. Also
         // requires the app's Info.plist UIBackgroundModes (bluetooth-central/peripheral) — app-side.
-        const val CENTRAL_RESTORE_ID = "chat.bitchat.mesh.central"
-        const val PERIPHERAL_RESTORE_ID = "chat.bitchat.mesh.peripheral"
         // CoreBluetooth has no MTU-request API: the central learns the negotiated ATT MTU and
         // exposes it via maximumWriteValueLengthForType; fragmentation uses the commonMain cap.
     }
@@ -140,11 +138,11 @@ internal class CoreBluetoothConnectionManager(
 
     private val centralManager = CBCentralManager(
         centralDelegate, null,
-        mapOf<Any?, Any?>(CBCentralManagerOptionRestoreIdentifierKey to CENTRAL_RESTORE_ID),
+        mapOf<Any?, Any?>(CBCentralManagerOptionRestoreIdentifierKey to CoreBluetoothRestoreIds.CENTRAL),
     )
     private val peripheralManager = CBPeripheralManager(
         peripheralDelegate, null,
-        mapOf<Any?, Any?>(CBPeripheralManagerOptionRestoreIdentifierKey to PERIPHERAL_RESTORE_ID),
+        mapOf<Any?, Any?>(CBPeripheralManagerOptionRestoreIdentifierKey to CoreBluetoothRestoreIds.PERIPHERAL),
     )
 
     private var active = false
@@ -200,6 +198,10 @@ internal class CoreBluetoothConnectionManager(
     }
 
     override fun stopServices() {
+        shutdown()
+    }
+
+    override fun shutdown() {
         active = false
         centralPolicy.stop()
         try {
@@ -230,11 +232,6 @@ internal class CoreBluetoothConnectionManager(
         subscribedCentrals.clear()
         frameAssemblers.clear()
         addressPeerMap.clear()
-        sendCore.pruneDirectedSpool()
-    }
-
-    fun shutdown() {
-        stopServices()
         sendCore.shutdown()
         outbound.shutdown()
         scope.cancel()
@@ -507,18 +504,18 @@ internal class CoreBluetoothConnectionManager(
                 ?.filterIsInstance<CBCharacteristic>()
                 ?.firstOrNull { it.UUID == characteristicCbUuid } ?: return
             val addr = peripheral.identifier.UUIDString
-            // Cache early so clientLinkSnapshots reports hasCharacteristic during notify setup.
+            // The characteristic is already outbound-writeable; expose it while notify setup runs.
             connectedPeripherals.put(addr, peripheral)
             peripheralCharacteristics.put(addr, char)
             pendingPeripherals.remove(addr)
             discoveredPeripherals.remove(addr)
-            // Link is fully write/notify-ready only after subscription confirms (below).
+            // Connected callbacks and spool flushing wait for inbound notifications below.
             peripheral.setNotifyValue(true, char)
         }
 
         /**
-         * Notify subscription confirmed (or failed). iOS reference flushes directed spool and
-         * treats the peer as connected only after this — writing before notify is enabled is racy.
+         * Notify subscription confirmed (or failed). Flush directed traffic once the link is
+         * bidirectional; [RadioLink.neighbors] may already use it for outbound writes.
          */
         @ObjCSignatureOverride
         override fun peripheral(

--- a/transport/protocol/src/androidHostTest/kotlin/com/app/transport/protocol/BinaryProtocolTest.kt
+++ b/transport/protocol/src/androidHostTest/kotlin/com/app/transport/protocol/BinaryProtocolTest.kt
@@ -577,6 +577,15 @@ class BinaryProtocolTest {
         }
     }
 
+    @Test
+    fun `encoder rejects unsupported versions instead of emitting v2-shaped garbage`() {
+        for (badVersion in listOf<UByte>(0u, 3u, 255u)) {
+            val packet = makePacket(version = badVersion, payload = "version test".toByteArray())
+
+            assertNull("Version $badVersion must not be encoded", BinaryProtocol.encode(packet))
+        }
+    }
+
     /**
      * Garbage data returns null
      *

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/MeshConstants.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/MeshConstants.kt
@@ -9,8 +9,8 @@ import kotlin.uuid.Uuid
  * Mesh-domain configuration constants (commonMain).
  *
  * Extracted from the monolith's god-config (`com.bitchat.android.util.AppConstants`) into the
- * transport module ahead of the `mesh/` extraction. Values are copied verbatim — this move is
- * behavior-neutral. iOS byte-compatibility: the packet TTL and the GATT UUIDs must stay identical.
+ * transport module ahead of the `mesh/` extraction. Wire-facing values are kept aligned with the
+ * native transport where interoperability requires it; local resource budgets may be stricter.
  * The BLE GATT UUIDs ([Mesh.Gatt]) are typed kotlin.uuid.Uuid (the project-wide idiom); platform
  * code adapts each to its native UUID type at the call site (java.util.UUID on Android via
  * Uuid.toJavaUuid(); CBUUID on native via CBUUID.UUIDWithString(uuid.toString())).
@@ -50,12 +50,41 @@ object MeshConstants {
         const val MAX_FRAGMENT_SIZE: Int = 469
         const val FRAGMENT_TIMEOUT_MS: Long = 30_000L
         const val CLEANUP_INTERVAL_MS: Long = 10_000L
-        // 1 MiB payload / 469-byte fragments ≈ 2236; headroom for TLV + packet framing.
+        // 1 MiB content / 469-byte fragments ≈ 2236; headroom for TLV + packet framing.
         // (Previously 256 ≈ 116 KiB — broke native↔KMP 1 MiB file interop.)
         const val MAX_FRAGMENTS_PER_ID: Int = 4096
-        const val MAX_FRAGMENT_TOTAL_BYTES: Int = 1_048_576
+        /**
+         * Cumulative reassembled **binary packet** budget (not bare content).
+         * Matches iOS `FileTransferLimits.maxFramedFileBytes`: 1 MiB content + worst-case
+         * UInt16 filename/MIME TLVs + v2 outer packet envelope (header/sender/recipient/sig).
+         */
+        val MAX_FRAGMENT_TOTAL_BYTES: Int = FileTransferLimits.maxFramedFileBytes
         const val MAX_ACTIVE_FRAGMENT_SETS: Int = 64
-        const val MAX_GLOBAL_FRAGMENT_TOTAL_BYTES: Long = 4L * 1_048_576L
+        val MAX_GLOBAL_FRAGMENT_TOTAL_BYTES: Long =
+            4L * FileTransferLimits.maxFramedFileBytes.toLong()
+    }
+
+    /**
+     * iOS `FileTransferLimits` parity — content ceiling and framed-packet headroom for
+     * BLE file transfers.
+     */
+    object FileTransferLimits {
+        /** Absolute ceiling for file content (voice, image, other). */
+        const val MAX_PAYLOAD_BYTES: Int = 1 * 1024 * 1024 // 1 MiB
+        const val MAX_VOICE_NOTE_BYTES: Int = 512 * 1024
+        const val MAX_IMAGE_BYTES: Int = 512 * 1024
+
+        // BinaryProtocol v2 header (16) + sender(8) + recipient(8) + signature(64) = 96
+        private const val BINARY_ENVELOPE_OVERHEAD: Int = 16 + 8 + 8 + 64
+        // TLV tags+lengths for name/size/mime/content header fields ≈ 18 + metadata
+        private const val TLV_ENVELOPE_BASE: Int = 18
+        private const val MAX_METADATA_BYTES: Int = 0xFFFF * 2 // fileName + mimeType UInt16 max
+
+        /** Worst-case full encoded packet for a max-size file (content + framing). */
+        val maxFramedFileBytes: Int =
+            MAX_PAYLOAD_BYTES + TLV_ENVELOPE_BASE + MAX_METADATA_BYTES + BINARY_ENVELOPE_OVERHEAD
+
+        fun isValidPayload(size: Int): Boolean = size <= MAX_PAYLOAD_BYTES
     }
 
     object Security {

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/MeshConstants.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/MeshConstants.kt
@@ -50,7 +50,9 @@ object MeshConstants {
         const val MAX_FRAGMENT_SIZE: Int = 469
         const val FRAGMENT_TIMEOUT_MS: Long = 30_000L
         const val CLEANUP_INTERVAL_MS: Long = 10_000L
-        const val MAX_FRAGMENTS_PER_ID: Int = 256
+        // 1 MiB payload / 469-byte fragments ≈ 2236; headroom for TLV + packet framing.
+        // (Previously 256 ≈ 116 KiB — broke native↔KMP 1 MiB file interop.)
+        const val MAX_FRAGMENTS_PER_ID: Int = 4096
         const val MAX_FRAGMENT_TOTAL_BYTES: Int = 1_048_576
         const val MAX_ACTIVE_FRAGMENT_SETS: Int = 64
         const val MAX_GLOBAL_FRAGMENT_TOTAL_BYTES: Long = 4L * 1_048_576L

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/model/BitchatFilePacket.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/model/BitchatFilePacket.kt
@@ -1,6 +1,7 @@
 package com.app.transport.model
 
 import com.app.common.utils.Log
+import com.app.transport.MeshConstants
 import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
 
@@ -8,16 +9,17 @@ import kotlinx.io.readByteArray
  * BitchatFilePacket: TLV-encoded file transfer payload for BLE mesh.
  * TLVs:
  *  - 0x01: filename (UTF-8)
- *  - 0x02: file size (8 bytes, UInt64)
+ *  - 0x02: file size (4 bytes, UInt32)
  *  - 0x03: mime type (UTF-8)
- *  - 0x04: content (bytes) — may appear multiple times for large files
+ *  - 0x04: content (bytes)
  *
- * Length field for TLV is 2 bytes (UInt16, big-endian) for all TLVs.
- * For large files, CONTENT is chunked into multiple TLVs of up to 65535 bytes each.
+ * Filename, file-size, and MIME TLVs use a 2-byte big-endian length. CONTENT uses a 4-byte
+ * big-endian length and is emitted as one TLV, allowing the outer v2 packet to exceed 64 KiB.
  *
- * Note: The outer BitchatPacket uses version 2 (4-byte payload length), so this
- * TLV payload can exceed 64 KiB even though each TLV value is limited to 65535 bytes.
- * Transport-level fragmentation then splits the final packet for BLE MTU.
+ * Content is capped at [MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES] (1 MiB),
+ * matching iOS FileTransferLimits.maxPayloadBytes.
+ *
+ * Transport-level fragmentation splits the final packet for BLE MTU.
  */
 data class BitchatFilePacket(
     val fileName: String,
@@ -33,18 +35,25 @@ data class BitchatFilePacket(
     fun encode(): ByteArray? {
         try {
             Log.d("BitchatFilePacket", "🔄 Encoding: name=$fileName, size=$fileSize, mime=$mimeType")
+            if (content.isEmpty() || !MeshConstants.FileTransferLimits.isValidPayload(content.size)) {
+                Log.e(
+                    "BitchatFilePacket",
+                    "❌ Content size is outside 1..${MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES}: ${content.size}",
+                )
+                return null
+            }
+            if (fileSize !in 0..MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES.toLong()) {
+                Log.e("BitchatFilePacket", "❌ Declared file size is outside native limit: $fileSize")
+                return null
+            }
             val nameBytes = fileName.encodeToByteArray()
             val mimeBytes = mimeType.encodeToByteArray()
-            // Validate bounds for 2-byte TLV lengths (per-TLV). CONTENT may exceed 65535 and will be chunked.
+            // Validate the fields that use 2-byte TLV lengths. CONTENT has a 4-byte length.
             if (nameBytes.size > 0xFFFF || mimeBytes.size > 0xFFFF) {
                 Log.e("BitchatFilePacket", "❌ TLV field too large: name=${nameBytes.size}, mime=${mimeBytes.size} (max: 65535)")
                 return null
             }
-            if (content.size > 0xFFFF) {
-                Log.d("BitchatFilePacket", "📦 Content exceeds 65535 bytes (${content.size}); will be split into multiple CONTENT TLVs")
-            } else {
-                Log.d("BitchatFilePacket", "📏 TLV sizes OK: name=${nameBytes.size}, mime=${mimeBytes.size}, content=${content.size}")
-            }
+            Log.d("BitchatFilePacket", "📏 TLV sizes OK: name=${nameBytes.size}, mime=${mimeBytes.size}, content=${content.size}")
 
             // kotlinx-io Buffer writes big-endian by default, matching the iOS wire (BIG_ENDIAN).
             val buf = Buffer()
@@ -101,7 +110,13 @@ data class BitchatFilePacket(
                         len = ((data[off].toInt() and 0xFF) shl 8) or (data[off + 1].toInt() and 0xFF)
                         off += 2
                     }
-                    if (len < 0 || off + len > data.size) return null
+                    if (len < 0 || len > data.size - off) return null
+                    if (t == TLVType.CONTENT) {
+                        val accumulated = contentBytes?.size ?: 0
+                        if (len > MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES - accumulated) {
+                            return null
+                        }
+                    }
                     val value = data.copyOfRange(off, off + len)
                     off += len
                     when (t) {
@@ -126,8 +141,16 @@ data class BitchatFilePacket(
                     }
                 }
                 val n = name ?: return null
-                val c = contentBytes ?: return null
+                val c = contentBytes?.takeIf { it.isNotEmpty() } ?: return null
+                if (!MeshConstants.FileTransferLimits.isValidPayload(c.size)) {
+                    Log.e(
+                        "BitchatFilePacket",
+                        "❌ Decoded content exceeds max payload: ${c.size} > ${MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES}",
+                    )
+                    return null
+                }
                 val s = size ?: c.size.toLong()
+                if (s !in 0..MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES.toLong()) return null
                 val m = mime ?: "application/octet-stream"
                 val result = BitchatFilePacket(n, s, m, c)
                 Log.d("BitchatFilePacket", "✅ Decoded: name=$n, size=$s, mime=$m, content=${c.size} bytes")

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/model/NoiseEncrypted.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/model/NoiseEncrypted.kt
@@ -23,9 +23,15 @@ enum class NoisePayloadType(val value: UByte) {
     DELIVERED(0x03u),           // Message was delivered
     GROUP_INVITE(0x06u),        // Creator-signed group state carried 1:1 over Noise (invite)
     GROUP_KEY_UPDATE(0x07u),    // Creator-signed group state (key rotation / roster update)
+    /** Live push-to-talk burst (same VoiceBurstPacket framing as public 0x29). iOS 0x08. */
+    VOICE_FRAME(0x08u),
     VERIFY_CHALLENGE(0x10u),    // Verification challenge
     VERIFY_RESPONSE(0x11u),     // Verification response
     VOUCH(0x12u),               // Batch of vouch attestations (transitive verification)
+    /**
+     * Legacy KMP-only path: private file inside Noise. Native iOS private files use
+     * outer signed [MessageType.FILE_TRANSFER] 0x22; keep 0x20 for older KMP peers.
+     */
     FILE_TRANSFER(0x20u);
 
 

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/model/RoutedPacket.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/model/RoutedPacket.kt
@@ -3,17 +3,31 @@ package com.app.transport.model
 import com.app.transport.protocol.BitchatPacket
 
 /**
- * Represents a routed packet with additional metadata
- * Used for processing and routing packets in the mesh network
+ * Represents a routed packet with additional metadata used for processing and routing
+ * in the mesh network.
+ *
+ * Identity split (iOS BLEIngressLinkRegistry parity):
+ * - [peerID] is the **logical origin** used for signature/Noise/session handling
+ *   ([BleIngressPacketContext.validationPeerID] / packet.senderID for normal traffic).
+ * - [relayAddress] is the local link the frame arrived on (loop avoidance / rebind).
+ * - [previousHopPeerID] is the peer bound to that link when known (direct neighbor);
+ *   for multi-hop this differs from [peerID] and must not be used for crypto.
  */
 data class RoutedPacket(
     val packet: BitchatPacket,
-    val peerID: String? = null,           // Who sent it (parsed from packet.senderID)
-    val relayAddress: String? = null,     // Address it came from (for avoiding loopback)
-    val transferId: String? = null,       // Optional stable transfer ID for progress tracking
+    /** Logical origin peer (crypto/handlers). Not necessarily the previous radio hop. */
+    val peerID: String? = null,
+    /** Opaque local link address this frame arrived on / will leave on. */
+    val relayAddress: String? = null,
+    val transferId: String? = null,
     // Queued directed send target: when set, the send-queue consumer delivers this frame
     // only to the named peer's link (broadcast fallback if the link is gone) at relay/bulk
     // priority. Local routing metadata only — never serialized to the wire. Used for
     // solicited gossip-sync responses, which must not bypass the bounded priority queue.
     val directedPeerID: String? = null,
+    /**
+     * Peer ID bound to [relayAddress] at ingress (previous hop), when known.
+     * Local metadata only — never on the wire. Null for locally originated packets.
+     */
+    val previousHopPeerID: String? = null,
 )

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/protocol/BinaryProtocol.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/protocol/BinaryProtocol.kt
@@ -10,7 +10,7 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /**
- * Message types - exact same as iOS version with Noise Protocol support
+ * Message type bytes shared with the native wire protocol.
  */
 enum class MessageType(val value: UByte) {
     ANNOUNCE(0x01u),
@@ -44,14 +44,14 @@ enum class MessageType(val value: UByte) {
 }
 
 /**
- * Special recipient IDs - exact same as iOS version
+ * Special recipient IDs shared with the native wire protocol.
  */
 object SpecialRecipients {
     val BROADCAST = ByteArray(8) { 0xFF.toByte() }  // All 0xFF = broadcast
 }
 
 /**
- * Binary packet format - 100% backward compatible with iOS version
+ * Binary packet layout for the shared v1/v2 wire protocol.
  *
  * Header (14 bytes for v1, 16 bytes for v2):
  * - Version: 1 byte
@@ -186,7 +186,8 @@ object BinaryProtocol {
     private const val SENDER_ID_SIZE = 8
     private const val RECIPIENT_ID_SIZE = 8
     private const val SIGNATURE_SIZE = 64
-    private const val MAX_PAYLOAD_LENGTH = 10_485_760  // 10 MiB — wire-level payload cap, same as iOS
+    // Generic decoder guard. BLE/file paths enforce their smaller type-specific limits before this.
+    private const val MAX_PAYLOAD_LENGTH = 10_485_760
 
     object Flags {
         const val HAS_RECIPIENT: UByte = 0x01u
@@ -206,6 +207,10 @@ object BinaryProtocol {
     
     fun encode(packet: BitchatPacket, padding: Boolean = true): ByteArray? {
         try {
+            if (packet.version != 1u.toUByte() && packet.version != 2u.toUByte()) {
+                Log.e("BinaryProtocol", "Refusing to encode unsupported version ${packet.version}")
+                return null
+            }
             // Fail loudly on inputs the wire format cannot represent — a silently
             // truncated frame would be misparsed by the decoder on the other side.
             packet.signature?.let { signature ->

--- a/transport/protocol/src/commonMain/kotlin/com/app/transport/protocol/BinaryProtocol.kt
+++ b/transport/protocol/src/commonMain/kotlin/com/app/transport/protocol/BinaryProtocol.kt
@@ -77,7 +77,13 @@ data class BitchatPacket(
     val payload: ByteArray,
     var signature: ByteArray? = null,  // Changed from val to var for packet signing
     var ttl: UByte,
-    var route: List<ByteArray>? = null // Optional source route: ordered list of peerIDs (8 bytes each), not including sender and final recipient
+    var route: List<ByteArray>? = null, // Optional source route: ordered list of peerIDs (8 bytes each), not including sender and final recipient
+    /**
+     * Request-Sync Response flag (wire Flags.IS_RSR = 0x10). Mutable and **not** covered by
+     * the Ed25519 signature (iOS BitchatPacket parity) — set on solicited gossip-sync replies
+     * so receivers skip clock-skew checks and attribute validation to the previous hop.
+     */
+    var isRSR: Boolean = false,
 ) {
 
     constructor(
@@ -116,7 +122,8 @@ data class BitchatPacket(
             payload = payload,
             signature = null, // Remove signature for signing
             route = route,
-            ttl = 0u.toUByte() // Use fixed TTL=0 for signing to ensure relay compatibility
+            ttl = 0u.toUByte(), // Use fixed TTL=0 for signing to ensure relay compatibility
+            isRSR = false, // RSR is mutable and not part of the signature (iOS parity)
         )
         return BinaryProtocol.encode(unsignedPacket)
     }
@@ -186,6 +193,8 @@ object BinaryProtocol {
         const val HAS_SIGNATURE: UByte = 0x02u
         const val IS_COMPRESSED: UByte = 0x04u
         const val HAS_ROUTE: UByte = 0x08u
+        /** Request-Sync Response — solicited gossip reply (iOS Flags.isRSR). */
+        const val IS_RSR: UByte = 0x10u
     }
 
     private fun getHeaderSize(version: UByte): Int {
@@ -257,6 +266,9 @@ object BinaryProtocol {
             // HAS_ROUTE is only supported for v2+ packets
             if (!packet.route.isNullOrEmpty() && packet.version >= 2u.toUByte()) {
                 flags = flags or Flags.HAS_ROUTE
+            }
+            if (packet.isRSR) {
+                flags = flags or Flags.IS_RSR
             }
             buffer.writeByte(flags.toByte())
 
@@ -374,6 +386,7 @@ object BinaryProtocol {
             val isCompressed = (flags and Flags.IS_COMPRESSED) != 0u.toUByte()
             // HAS_ROUTE is only valid for v2+ packets; ignore the flag for v1
             val hasRoute = (version >= 2u.toUByte()) && (flags and Flags.HAS_ROUTE) != 0u.toUByte()
+            val isRSR = (flags and Flags.IS_RSR) != 0u.toUByte()
 
             // Payload length - version-dependent (2 or 4 bytes)
             val payloadLength = if (version >= 2u.toUByte()) {
@@ -482,7 +495,8 @@ object BinaryProtocol {
                 payload = payload,
                 signature = signature,
                 ttl = ttl,
-                route = route
+                route = route,
+                isRSR = isRSR,
             )
             
         } catch (e: Throwable) {

--- a/transport/protocol/src/commonTest/kotlin/com/app/transport/model/BitchatFilePacketLimitsTest.kt
+++ b/transport/protocol/src/commonTest/kotlin/com/app/transport/model/BitchatFilePacketLimitsTest.kt
@@ -1,0 +1,102 @@
+package com.app.transport.model
+
+import com.app.transport.MeshConstants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** P0.4: 1 MiB content limit and framed-packet headroom for fragment reassembly. */
+class BitchatFilePacketLimitsTest {
+
+    @Test
+    fun encodeRejectsContentOver1MiB() {
+        val over = MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES + 1
+        val packet = BitchatFilePacket(
+            fileName = "big.bin",
+            fileSize = over.toLong(),
+            mimeType = "application/octet-stream",
+            content = ByteArray(over) { 0xAB.toByte() },
+        )
+        assertNull(packet.encode())
+    }
+
+    @Test
+    fun encodeRejectsDeclaredSizeOutsideNativeLimit() {
+        val packet = BitchatFilePacket(
+            fileName = "bad.bin",
+            fileSize = MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES.toLong() + 1,
+            mimeType = "application/octet-stream",
+            content = byteArrayOf(1),
+        )
+
+        assertNull(packet.encode())
+    }
+
+    @Test
+    fun encodeRejectsEmptyContentLikeNativeDecoder() {
+        val packet = BitchatFilePacket(
+            fileName = "empty.bin",
+            fileSize = 0,
+            mimeType = "application/octet-stream",
+            content = byteArrayOf(),
+        )
+
+        assertNull(packet.encode())
+    }
+
+    @Test
+    fun encodeAcceptsExact1MiBContent() {
+        val size = MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES
+        val packet = BitchatFilePacket(
+            fileName = "a.bin",
+            fileSize = size.toLong(),
+            mimeType = "application/octet-stream",
+            content = ByteArray(size) { (it % 251).toByte() },
+        )
+        val encoded = packet.encode()
+        assertNotNull(encoded)
+        val decoded = BitchatFilePacket.decode(encoded)
+        assertNotNull(decoded)
+        assertEquals(size, decoded.content.size)
+    }
+
+    @Test
+    fun decodeRejectsContentOver1MiB() {
+        val size = MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES
+        val ok = BitchatFilePacket(
+            fileName = "a.bin",
+            fileSize = size.toLong(),
+            mimeType = "application/octet-stream",
+            content = ByteArray(size),
+        ).encode()!!
+        val secondContentTlv = byteArrayOf(0x04, 0x00, 0x00, 0x00, 0x01, 0x7F)
+
+        assertNull(BitchatFilePacket.decode(ok + secondContentTlv))
+    }
+
+    @Test
+    fun decodeRejectsDeclaredSizeOutsideNativeLimit() {
+        val malformed = byteArrayOf(
+            0x01, 0x00, 0x01, 'a'.code.toByte(),
+            0x02, 0x00, 0x04, 0x00, 0x10, 0x00, 0x01,
+            0x04, 0x00, 0x00, 0x00, 0x01, 0x7F,
+        )
+
+        assertNull(BitchatFilePacket.decode(malformed))
+    }
+
+    @Test
+    fun maxFramedFileBytesExceedsBare1MiB() {
+        // Fragment cumulative gate must fit content + TLV + outer packet envelope.
+        assertTrue(
+            MeshConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES >
+                MeshConstants.FileTransferLimits.MAX_PAYLOAD_BYTES,
+        )
+        assertTrue(
+            MeshConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES >=
+                MeshConstants.FileTransferLimits.maxFramedFileBytes,
+        )
+    }
+}

--- a/transport/protocol/src/commonTest/kotlin/com/app/transport/model/VoiceFrameNoisePayloadTest.kt
+++ b/transport/protocol/src/commonTest/kotlin/com/app/transport/model/VoiceFrameNoisePayloadTest.kt
@@ -1,0 +1,25 @@
+package com.app.transport.model
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/** P0.5: private live voice is NoisePayloadType.VOICE_FRAME = 0x08. */
+class VoiceFrameNoisePayloadTest {
+
+    @Test
+    fun voiceFrameTypeIs0x08() {
+        assertEquals(0x08u.toUByte(), NoisePayloadType.VOICE_FRAME.value)
+    }
+
+    @Test
+    fun encodeDecodeRoundTrip() {
+        val burst = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+        val encoded = NoisePayload(NoisePayloadType.VOICE_FRAME, burst).encode()
+        assertEquals(0x08, encoded[0].toInt() and 0xFF)
+        val decoded = assertNotNull(NoisePayload.decode(encoded))
+        assertEquals(NoisePayloadType.VOICE_FRAME, decoded.type)
+        assertContentEquals(burst, decoded.data)
+    }
+}

--- a/transport/protocol/src/commonTest/kotlin/com/app/transport/protocol/IsRsrFlagTest.kt
+++ b/transport/protocol/src/commonTest/kotlin/com/app/transport/protocol/IsRsrFlagTest.kt
@@ -1,0 +1,45 @@
+package com.app.transport.protocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Wire flag Flags.IS_RSR = 0x10 round-trip (iOS BinaryProtocol parity). */
+class IsRsrFlagTest {
+
+    private fun basePacket(isRSR: Boolean) = BitchatPacket(
+        version = 1u,
+        type = MessageType.MESSAGE.value,
+        senderID = ByteArray(8) { 0x11 },
+        recipientID = ByteArray(8) { 0x22 },
+        timestamp = 1_700_000_000_000uL,
+        payload = byteArrayOf(1, 2, 3),
+        signature = null,
+        ttl = 7u,
+        isRSR = isRSR,
+    )
+
+    @Test
+    fun encodeDecode_preservesIsRsr() {
+        val encoded = BinaryProtocol.encode(basePacket(isRSR = true), padding = false)!!
+        val decoded = BinaryProtocol.decode(encoded)!!
+        assertTrue(decoded.isRSR)
+        assertEquals(MessageType.MESSAGE.value, decoded.type)
+    }
+
+    @Test
+    fun encodeDecode_defaultIsRsrFalse() {
+        val encoded = BinaryProtocol.encode(basePacket(isRSR = false), padding = false)!!
+        val decoded = BinaryProtocol.decode(encoded)!!
+        assertFalse(decoded.isRSR)
+    }
+
+    @Test
+    fun signingCopy_clearsIsRsr() {
+        val packet = basePacket(isRSR = true)
+        val forSign = packet.toBinaryDataForSigning()!!
+        val decoded = BinaryProtocol.decode(forSign)!!
+        assertFalse(decoded.isRSR, "isRSR must not be part of the signed representation")
+    }
+}


### PR DESCRIPTION
## Summary

Completes the pure-BLE transport parity audit overlay against `bitMessage/main`.

- closes the RSR P0 path: logical-origin preservation, multi-hop security validation, RSR fragment propagation, self-authored fragment suppression, request-sync handling, and private-file outer-packet coverage
- hardens voice reassembly with 32 active bursts, 512 KiB per burst, injected 30-second expiry, duplicate-start handling, and recovery after eviction
- bounds BLE ingress history at 4,096 FIFO entries under concurrency and preserves expiry semantics
- preserves local message UUIDs across signed self-broadcast replay to prevent duplicate UI rows
- rejects unsupported binary protocol versions and malformed/oversized file packets before allocation
- terminally cleans up BLE managers, owned scopes, send queues, and directed spools on stop/reset
- requeues failed typed Noise payloads in FIFO order after handshake
- aligns CoreBluetooth restoration identifiers with the native reference implementation
- keeps private mesh voice out of the Nostr DM ingest boundary

## Verification

Fresh full tasks:

- `:core:data:testAndroidHostTest --rerun-tasks` — 160 tests, 0 failures/errors
- `:transport:mesh:testAndroidHostTest --rerun-tasks` — 322 tests, 0 failures/errors
- `:transport:mesh:iosSimulatorArm64Test --rerun-tasks` — 127 tests, 0 failures/errors
- `:transport:protocol:testAndroidHostTest --rerun-tasks` — 226 tests, 0 failures/errors
- `:transport:protocol:iosSimulatorArm64Test --rerun-tasks` — 147 tests, 0 failures/errors
- `:core:domain:testAndroidHostTest --rerun-tasks` — 89 tests, 0 failures/errors
- `:core:crypto:testAndroidHostTest --rerun-tasks` — 42 tests, 0 failures/errors, 1 skipped

Total reported: 1,113 tests; 0 failures; 0 errors; 1 skipped.

Also passed `:transport:mesh:compileKotlinIosSimulatorArm64 --rerun-tasks` and `git diff HEAD --check`.

## Audit references

- target/base: `bitMessage/main` at `e4995f84de843d63a9bff2c0d49539067de60957`
- native Android reference: `75a7b06f37b93b3d4c7c1cc78340405f10e080d6`
- upstream reference: `b7f0b33d3a267c770d3d5a65ee2d8c7e755450db`
- audit closure commit: `6ac5b573d4aafdea8a920a7a194a71e4aad0b1c3`

## Explicit non-claims / backlog

This PR does not claim complete application-level parity outside pure transport behavior.

- legacy `StoreForwardManager.cacheMessage` remains unwired; the active pure-BLE Courier path is separate and wired
- recent-peripheral reconnect caching, subscription/announce throttling, and stale source-route failure caching remain P2 efficiency work
- aggregate file-cache quota and MIME policy remain storage-policy work; the per-packet 1 MiB protocol boundary is enforced here
- private voice transport type `0x08` is supported, but application-level PTT capture/playback/consumer parity is outside this transport PR
- maintenance-cycle observability counters remain diagnostics backlog

The pre-existing forbidden untracked audit/workspace paths were not added.

## Merge gate

Draft only. Do not merge until an independent review explicitly returns:

`MERGE APPROVED BY INDEPENDENT REVIEW`
